### PR TITLE
if snapshot name already exists and -force specified, safely overwrite it

### DIFF
--- a/builder/hcloud/step_create_snapshot.go
+++ b/builder/hcloud/step_create_snapshot.go
@@ -40,12 +40,11 @@ func (s *stepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) 
 			if err1 == nil {
 				return multistep.ActionContinue
 			} else {
-				err := fmt.Errorf("Error creating snapshot: %s", err)
+				err := fmt.Errorf("Error creating snapshot: %s", err1)
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
 			}
-
 		}
 	}
 }

--- a/builder/hcloud/step_create_snapshot.go
+++ b/builder/hcloud/step_create_snapshot.go
@@ -34,18 +34,15 @@ func (s *stepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) 
 	state.Put("snapshot_id", result.Image.ID)
 	state.Put("snapshot_name", c.SnapshotName)
 	_, errCh := client.Action.WatchProgress(ctx, result.Action)
-	for {
-		select {
-		case err1 := <-errCh:
-			if err1 == nil {
-				return multistep.ActionContinue
-			} else {
-				err := fmt.Errorf("Error creating snapshot: %s", err1)
-				state.Put("error", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
-		}
+
+	err1 := <-errCh
+	if err1 == nil {
+		return multistep.ActionContinue
+	} else {
+		err := fmt.Errorf("Error creating snapshot: %s", err1)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
 	}
 }
 

--- a/builder/hcloud/step_create_snapshot.go
+++ b/builder/hcloud/step_create_snapshot.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hetznercloud/hcloud-go/hcloud"
 )
 
+const OldSnapshotID = "old_snapshot_id"
+
 type stepCreateSnapshot struct{}
 
 //nolint: gosimple
@@ -36,14 +38,33 @@ func (s *stepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) 
 	_, errCh := client.Action.WatchProgress(ctx, result.Action)
 
 	err1 := <-errCh
-	if err1 == nil {
-		return multistep.ActionContinue
-	} else {
+	if err1 != nil {
 		err := fmt.Errorf("Error creating snapshot: %s", err1)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
+
+	oldSnap, found := state.GetOk(OldSnapshotID)
+	if !found {
+		return multistep.ActionContinue
+	}
+	oldSnapID := oldSnap.(int)
+
+	// The pre validate step has been invoked with -force AND found an existing
+	// snapshot with the same name.
+	// Now that we safely saved the new snapshot, let's delete the old one,
+	// thus implementing an overwrite semantics.
+	ui.Say(fmt.Sprintf("Deleting old snapshot with ID: %d", oldSnapID))
+	image := &hcloud.Image{ID: oldSnapID}
+	_, err = client.Image.Delete(ctx, image)
+	if err != nil {
+		err := fmt.Errorf("Error deleting old snapshot with ID: %d: %s", oldSnapID, err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+	return multistep.ActionContinue
 }
 
 func (s *stepCreateSnapshot) Cleanup(state multistep.StateBag) {

--- a/builder/hcloud/step_create_snapshot_test.go
+++ b/builder/hcloud/step_create_snapshot_test.go
@@ -1,0 +1,147 @@
+package hcloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/hetznercloud/hcloud-go/hcloud/schema"
+)
+
+type FailCause int
+
+const (
+	Pass FailCause = iota
+	FailCreateImage
+	FailWatchProgress
+)
+
+func TestStepCreateSnapshot(t *testing.T) {
+	testCases := []struct {
+		name       string
+		snapName   string
+		failCause  FailCause // zero value: pass
+		wantAction multistep.StepAction
+	}{
+		{
+			name:       "happy path",
+			snapName:   "dummy-snap",
+			wantAction: multistep.ActionContinue,
+		},
+		{
+			name:       "fail create image",
+			snapName:   "dummy-snap",
+			failCause:  FailCreateImage,
+			wantAction: multistep.ActionHalt,
+		},
+		{
+			name:       "fail watch progress",
+			snapName:   "dummy-snap",
+			failCause:  FailWatchProgress,
+			wantAction: multistep.ActionHalt,
+		},
+	}
+	const serverID = 42
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errors := make(chan error, 1)
+			state, teardown := setupStepCreateSnapshot(errors, tc.failCause)
+			defer teardown()
+
+			step := &stepCreateSnapshot{}
+			config := Config{
+				SnapshotName: tc.snapName,
+			}
+			// do not output to stdout or console
+			state.Put("ui", &packersdk.MockUi{})
+			state.Put("config", &config)
+			state.Put("server_id", serverID)
+
+			if action := step.Run(context.Background(), state); action != tc.wantAction {
+				t.Errorf("step.Run: want: %v; got: %v", tc.wantAction, action)
+			}
+
+			select {
+			case err := <-errors:
+				t.Errorf("server: got: %s", err)
+			default:
+			}
+		})
+	}
+}
+
+// Configure a httptest server to reply to the request to create a snapshot.
+// React with the appropriate failCause.
+// Report errors on the errors channel (cannot use testing.T, it runs on a different goroutine).
+// Return a tuple (state, teardown) where:
+// - state (containing the client) is ready to be passed to the step.Run() method.
+// - teardown is a function meant to be deferred from the test.
+func setupStepCreateSnapshot(
+	errors chan<- error,
+	failCause FailCause,
+) (*multistep.BasicStateBag, func()) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			errors <- fmt.Errorf("fake server: reading request: %s", err)
+			return
+		}
+		reqDump := fmt.Sprintf("fake server: request:\n%s %s\nbody: %s", r.Method, r.URL.Path, string(buf))
+		if testing.Verbose() {
+			fmt.Println(reqDump)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		var response interface{}
+		action := schema.Action{
+			ID:       13,
+			Progress: 100,
+			Status:   "success",
+		}
+
+		if r.Method == http.MethodPost && r.URL.Path == "/servers/42/actions/create_image" {
+			if failCause == FailCreateImage {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			response = schema.ServerActionCreateImageResponse{Action: action}
+		} else if r.Method == http.MethodGet && r.URL.Path == "/actions/13" {
+			if failCause == FailWatchProgress {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			response = schema.ActionGetResponse{Action: action}
+		}
+
+		if response != nil {
+			if err := enc.Encode(response); err != nil {
+				errors <- fmt.Errorf("fake server: encoding reply: %s", err)
+			}
+			return
+		}
+
+		// no match: report error
+		w.WriteHeader(http.StatusBadRequest)
+		errors <- fmt.Errorf(reqDump)
+	}))
+
+	state := multistep.BasicStateBag{}
+	client := hcloud.NewClient(hcloud.WithEndpoint(ts.URL))
+	state.Put("hcloudClient", client)
+
+	teardown := func() {
+		ts.Close()
+	}
+	return &state, teardown
+}

--- a/builder/hcloud/step_pre_validate_test.go
+++ b/builder/hcloud/step_pre_validate_test.go
@@ -16,46 +16,41 @@ import (
 )
 
 func TestStepPreValidate(t *testing.T) {
+	fakeSnapNames := []string{"snapshot-old"}
+
 	testCases := []struct {
-		name          string
-		fakeSnapNames []string
-		step          stepPreValidate
-		wantAction    multistep.StepAction
+		name       string
+		step       stepPreValidate
+		wantAction multistep.StepAction
 	}{
 		{
-			"happy path: snapshot name is new",
-			[]string{"snapshot-old"},
-			stepPreValidate{
-				SnapshotName: "snapshot-new",
-			},
-			multistep.ActionContinue,
+			name:       "snapshot name new, success",
+			step:       stepPreValidate{SnapshotName: "snapshot-new"},
+			wantAction: multistep.ActionContinue,
 		},
 		{
-			"want failure: old snapshot name",
-			[]string{"snapshot-old"},
-			stepPreValidate{
-				SnapshotName: "snapshot-old",
-			},
-			multistep.ActionHalt,
+			name:       "snapshot name old, failure",
+			step:       stepPreValidate{SnapshotName: "snapshot-old"},
+			wantAction: multistep.ActionHalt,
 		},
 		{
-			"old snapshot name but force flag",
-			[]string{"snapshot-old"},
-			stepPreValidate{
-				Force:        true,
-				SnapshotName: "snapshot-old",
-			},
-			multistep.ActionContinue,
+			name:       "snapshot name old with force flag, success",
+			step:       stepPreValidate{SnapshotName: "snapshot-old", Force: true},
+			wantAction: multistep.ActionContinue,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			errors := make(chan error, 1)
-			state, teardown := setupStepPreValidate(errors, tc.fakeSnapNames)
+			state, teardown := setupStepPreValidate(errors, fakeSnapNames)
 			defer teardown()
 
-			// do not output to stdout or console
-			state.Put("ui", &packersdk.MockUi{})
+			if testing.Verbose() {
+				state.Put("ui", packersdk.TestUi(t))
+			} else {
+				// do not output to stdout or console
+				state.Put("ui", &packersdk.MockUi{})
+			}
 
 			if action := tc.step.Run(context.Background(), state); action != tc.wantAction {
 				t.Errorf("step.Run: want: %v; got: %v", tc.wantAction, action)
@@ -69,7 +64,7 @@ func TestStepPreValidate(t *testing.T) {
 	}
 }
 
-// Configure a httptest server to return the list of fakeSnapNames.
+// Configure a httptest server to reply to the requests done by stepPrevalidate.
 // Report errors on the errors channel (cannot use testing.T, it runs on a different goroutine).
 // Return a tuple (state, teardown) where:
 // - state (containing the client) is ready to be passed to the step.Run() method.
@@ -81,7 +76,8 @@ func setupStepPreValidate(errors chan<- error, fakeSnapNames []string) (*multist
 			errors <- fmt.Errorf("fake server: reading request: %s", err)
 			return
 		}
-		reqDump := fmt.Sprintf("fake server: request:\n%s %s\nbody: %s", r.Method, r.URL.Path, string(buf))
+		reqDump := fmt.Sprintf("fake server: request:\n    %s %s\n    body: %s",
+			r.Method, r.URL.Path, string(buf))
 		if testing.Verbose() {
 			fmt.Println(reqDump)
 		}


### PR DESCRIPTION
This is on top of #17, but unfortunately this GitHub UI doesn't show only the incremental work. Best reviewed commit-per-commit.

With previous PR #17 we detected if a snapshot name was already present and refused to proceed, unless `packer build -force` was specified. If it was specified, then we would _add_ the new snapshot to the existing one.

This PR brings the behavior of this plugin completely on par with the expected behavior of `packer build -force`:

    -force    Force a build to continue if artifacts exist, deletes existing artifacts.

The overwite is done safely: first a new image is built and a snapshot is taken. Only if the new snapshot is taken with success we then delete the old one.

As for PR #17, this PR comes with full test coverage.

NOTE: while developing this feature, I noticed two pre-existing bugs, fixed in commits ~~efcc738~~ rebase: 930a8e9  and ~~d9b9ba3~~ rebase: f083f10. Probably worthwile to involve somebody from Hetzener cloud to double-check.

Closes #14

EDIT: rebased over master, now this PR contains only commits related to itself.