### PR TITLE
Add `ssh_username` to the list of required options

### DIFF
--- a/docs/builders/hetzner-cloud.mdx
+++ b/docs/builders/hetzner-cloud.mdx
@@ -45,6 +45,8 @@ builder.
 
 - `server_type` (string) - ID or name of the server type this server should
   be created with.
+  
+- `ssh_username` (string) - The username to connect to SSH with.
 
 ### Optional:
 


### PR DESCRIPTION
Required options according to the [docs](https://www.packer.io/plugins/builders/hetzner-cloud#required-builder-configuration-options)
```
// ...
source "hcloud" "ubuntu" {
  // token was set using HCLOUD_TOKEN
  image = "ubuntu-20.04"
  location = "fsn1"
  server_type = "cx11"
}
// ...
```
`packer validate` output:
```
Error: 1 error(s) occurred:

* An ssh_username must be specified
  Note: some builders used to default ssh_username to "root".
```

