### PR TITLE
Use SDK communicator to generate SSH key pair

### DIFF
--- a/builder/hcloud/builder_acc_test.go
+++ b/builder/hcloud/builder_acc_test.go
@@ -37,7 +37,8 @@ const testBuilderAccBasic = `
 		"server_type": "cx11",
 		"image": "ubuntu-18.04",
 		"user_data": "",
-		"user_data_file": ""
+		"user_data_file": "",
+		"ssh_username": "root"
 	}]
 }
 `

--- a/builder/hcloud/builder_acc_test.go
+++ b/builder/hcloud/builder_acc_test.go
@@ -35,7 +35,7 @@ const testBuilderAccBasic = `
 		"type": "test",
 		"location": "nbg1",
 		"server_type": "cx11",
-		"image": "ubuntu-18.04",
+		"image": "ubuntu-22.04",
 		"user_data": "",
 		"user_data_file": "",
 		"ssh_username": "root"

--- a/builder/hcloud/step_create_sshkey.go
+++ b/builder/hcloud/step_create_sshkey.go
@@ -2,26 +2,16 @@ package hcloud
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"log"
-	"os"
-	"runtime"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/uuid"
 	"github.com/hetznercloud/hcloud-go/hcloud"
-	"golang.org/x/crypto/ssh"
 )
 
 type stepCreateSSHKey struct {
-	Debug        bool
-	DebugKeyPath string
-
 	keyId int
 }
 
@@ -31,32 +21,10 @@ func (s *stepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	c := state.Get("config").(*Config)
 	ui.Say("Creating temporary ssh key for server...")
 
-	priv, err := rsa.GenerateKey(rand.Reader, 2014)
-	if err != nil {
-		state.Put("error", fmt.Errorf("Error generating RSA key: %s", err))
-		ui.Error(err.Error())
+	if c.Comm.SSHPublicKey == nil {
+		ui.Say("No public SSH key found")
 		return multistep.ActionHalt
 	}
-	// ASN.1 DER encoded form
-	privDER := x509.MarshalPKCS1PrivateKey(priv)
-	privBLK := pem.Block{
-		Type:    "RSA PRIVATE KEY",
-		Headers: nil,
-		Bytes:   privDER,
-	}
-
-	// Set the private key in the config for later
-	c.Comm.SSHPrivateKey = pem.EncodeToMemory(&privBLK)
-
-	// Marshal the public key into SSH compatible format
-	pub, err := ssh.NewPublicKey(&priv.PublicKey)
-	if err != nil {
-		state.Put("error", fmt.Errorf("Error generating public key: %s", err))
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
-
-	pubSSHFormat := string(ssh.MarshalAuthorizedKey(pub))
 
 	// The name of the public key on the Hetzner Cloud
 	name := fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
@@ -64,7 +32,7 @@ func (s *stepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	// Create the key!
 	key, _, err := client.SSHKey.Create(ctx, hcloud.SSHKeyCreateOpts{
 		Name:      name,
-		PublicKey: pubSSHFormat,
+		PublicKey: string(c.Comm.SSHPublicKey),
 	})
 	if err != nil {
 		err := fmt.Errorf("Error creating temporary SSH key: %s", err)
@@ -81,30 +49,6 @@ func (s *stepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	// Remember some state for the future
 	state.Put("ssh_key_id", key.ID)
 
-	// If we're in debug mode, output the private key to the working directory.
-	if s.Debug {
-		ui.Message(fmt.Sprintf("Saving key for debug purposes: %s", s.DebugKeyPath))
-		f, err := os.Create(s.DebugKeyPath)
-		if err != nil {
-			state.Put("error", fmt.Errorf("Error saving debug key: %s", err))
-			return multistep.ActionHalt
-		}
-		defer f.Close()
-
-		// Write the key out
-		if _, err := f.Write(pem.EncodeToMemory(&privBLK)); err != nil {
-			state.Put("error", fmt.Errorf("Error saving debug key: %s", err))
-			return multistep.ActionHalt
-		}
-
-		// Chmod it so that it is SSH ready
-		if runtime.GOOS != "windows" {
-			if err := f.Chmod(0600); err != nil {
-				state.Put("error", fmt.Errorf("Error setting permissions of debug key: %s", err))
-				return multistep.ActionHalt
-			}
-		}
-	}
 	return multistep.ActionContinue
 }
 

--- a/docs/builders/hetzner-cloud.mdx
+++ b/docs/builders/hetzner-cloud.mdx
@@ -118,7 +118,7 @@ access tokens:
     {
       "type": "hcloud",
       "token": "YOUR API KEY",
-      "image": "ubuntu-18.04",
+      "image": "ubuntu-22.04",
       "location": "nbg1",
       "server_type": "cx11",
       "ssh_username": "root"


### PR DESCRIPTION
I've added a `communicator.StepSSHKeyGen` to let the communicator pre-generate the SSH key pair, used that key and removed the code that creates a new RSA SSH key pair in `stepCreateSSHKey`.

This means the plugin now supports `temporary_key_pair_type` and `temporary_key_pair_bits`.

I used https://github.com/hashicorp/packer-plugin-digitalocean/commit/e88d4df09e8085fe4ed76fc219762f3e7970186b as a baseline.

I've run the acceptance test and it completes successfully, after adding the required `ssh_username`.
I don't think this needs any change to the docs.