### PR TITLE
Update docs to be HCL2

### DIFF
--- a/docs/builders/hetzner-cloud.mdx
+++ b/docs/builders/hetzner-cloud.mdx
@@ -114,17 +114,16 @@ builder.
 Here is a basic example. It is completely valid as soon as you enter your own
 access tokens:
 
-```json
-{
-  "builders": [
-    {
-      "type": "hcloud",
-      "token": "YOUR API KEY",
-      "image": "ubuntu-22.04",
-      "location": "nbg1",
-      "server_type": "cx11",
-      "ssh_username": "root"
-    }
-  ]
+```hcl
+source "hcloud" "basic_example" {
+	token = "YOUR API TOKEN"
+  image = "ubuntu-22.04"
+	location = "nbg1"
+	server_type = "cx11"
+	ssh_username = "root"
+}
+
+build {
+	sources  = ["source.hcloud.basic_example"]
 }
 ```

--- a/docs/builders/hetzner-cloud.mdx
+++ b/docs/builders/hetzner-cloud.mdx
@@ -57,8 +57,8 @@ builder.
 
   ```hcl
   image_filter {
-  	most_recent   = true
-	with_selector = ["name==my-image"]
+    most_recent   = true
+    with_selector = ["name==my-image"]
   }
   ```
 
@@ -114,14 +114,14 @@ access tokens:
 
 ```hcl
 source "hcloud" "basic_example" {
-	token = "YOUR API TOKEN"
-	image = "ubuntu-22.04"
-	location = "nbg1"
-	server_type = "cx11"
-	ssh_username = "root"
+  token = "YOUR API TOKEN"
+  image = "ubuntu-22.04"
+  location = "nbg1"
+  server_type = "cx11"
+  ssh_username = "root"
 }
 
 build {
-	sources  = ["source.hcloud.basic_example"]
+  sources  = ["source.hcloud.basic_example"]
 }
 ```

--- a/docs/builders/hetzner-cloud.mdx
+++ b/docs/builders/hetzner-cloud.mdx
@@ -55,12 +55,10 @@ builder.
 - `image_filter` (object) - Filters used to populate the `filter`
   field. Example:
 
-  ```json
-  {
-    "image_filter": {
-      "with_selector": ["name==my-image"],
-      "most_recent": true
-    }
+  ```hcl
+  image_filter {
+  	most_recent   = true
+	with_selector = ["name==my-image"]
   }
   ```
 
@@ -117,7 +115,7 @@ access tokens:
 ```hcl
 source "hcloud" "basic_example" {
 	token = "YOUR API TOKEN"
-  image = "ubuntu-22.04"
+	image = "ubuntu-22.04"
 	location = "nbg1"
 	server_type = "cx11"
 	ssh_username = "root"


### PR DESCRIPTION
Making a change to the builder doc to remove JSON examples in favour of using hcl2, the preferred configuration language.

Closes #28

