### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs/builders/hetzner-cloud.mdx
+++ b/docs/builders/hetzner-cloud.mdx
@@ -30,7 +30,7 @@ segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 ### Required Builder Configuration options:
@@ -84,7 +84,7 @@ builder.
 
 - `snapshot_name` (string) - The name of the resulting snapshot that will
   appear in your account as image description. Defaults to `packer-{{timestamp}}` (see
-  [configuration templates](/docs/templates/legacy_json_templates/engine) for more info). If you want to reference the image as a sample in your terraform configuration please use the image id or the `snapshot_labels`.
+  [configuration templates](/packer/docs/templates/legacy_json_templates/engine) for more info). If you want to reference the image as a sample in your terraform configuration please use the image id or the `snapshot_labels`.
 
 - `snapshot_labels` (map of key/value strings) - Key/value pair labels to
   apply to the created image.


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them

