### PR TITLE
Change server type after create

### DIFF
--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -28,11 +28,12 @@ type Config struct {
 
 	PollInterval time.Duration `mapstructure:"poll_interval"`
 
-	ServerName  string       `mapstructure:"server_name"`
-	Location    string       `mapstructure:"location"`
-	ServerType  string       `mapstructure:"server_type"`
-	Image       string       `mapstructure:"image"`
-	ImageFilter *imageFilter `mapstructure:"image_filter"`
+	ServerName        string       `mapstructure:"server_name"`
+	Location          string       `mapstructure:"location"`
+	ServerType        string       `mapstructure:"server_type"`
+	UpgradeServerType string       `mapstructure:"upgrade_server_type"`
+	Image             string       `mapstructure:"image"`
+	ImageFilter       *imageFilter `mapstructure:"image_filter"`
 
 	SnapshotName   string            `mapstructure:"snapshot_name"`
 	SnapshotLabels map[string]string `mapstructure:"snapshot_labels"`

--- a/builder/hcloud/config.hcl2spec.go
+++ b/builder/hcloud/config.hcl2spec.go
@@ -73,6 +73,7 @@ type FlatConfig struct {
 	ServerName                *string           `mapstructure:"server_name" cty:"server_name" hcl:"server_name"`
 	Location                  *string           `mapstructure:"location" cty:"location" hcl:"location"`
 	ServerType                *string           `mapstructure:"server_type" cty:"server_type" hcl:"server_type"`
+	UpgradeServerType         *string           `mapstructure:"upgrade_server_type" cty:"upgrade_server_type" hcl:"upgrade_server_type"`
 	Image                     *string           `mapstructure:"image" cty:"image" hcl:"image"`
 	ImageFilter               *FlatimageFilter  `mapstructure:"image_filter" cty:"image_filter" hcl:"image_filter"`
 	SnapshotName              *string           `mapstructure:"snapshot_name" cty:"snapshot_name" hcl:"snapshot_name"`
@@ -158,6 +159,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"server_name":                  &hcldec.AttrSpec{Name: "server_name", Type: cty.String, Required: false},
 		"location":                     &hcldec.AttrSpec{Name: "location", Type: cty.String, Required: false},
 		"server_type":                  &hcldec.AttrSpec{Name: "server_type", Type: cty.String, Required: false},
+		"upgrade_server_type":          &hcldec.AttrSpec{Name: "upgrade_server_type", Type: cty.String, Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
 		"image_filter":                 &hcldec.BlockSpec{TypeName: "image_filter", Nested: hcldec.ObjectSpec((*FlatimageFilter)(nil).HCL2Spec())},
 		"snapshot_name":                &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},

--- a/docs/builders/hetzner-cloud.mdx
+++ b/docs/builders/hetzner-cloud.mdx
@@ -109,6 +109,9 @@ builder.
   enables simple installation of custom operating systems. `linux64`
   `linux32` or `freebsd64`
 
+- `upgrade_server_type` (string) - ID or name of the server type this server should
+  be upgraded to, without changing the disk size.
+
 ## Basic Example
 
 Here is a basic example. It is completely valid as soon as you enter your own

--- a/docs/builders/hetzner-cloud.mdx
+++ b/docs/builders/hetzner-cloud.mdx
@@ -110,7 +110,8 @@ builder.
   `linux32` or `freebsd64`
 
 - `upgrade_server_type` (string) - ID or name of the server type this server should
-  be upgraded to, without changing the disk size.
+  be upgraded to, without changing the disk size. Improves building performance.
+  The resulting snapshot is compatible with smaller server types and disk sizes.
 
 ## Basic Example
 


### PR DESCRIPTION
To speed up image builds we like to upgrade the server to a bigger type without changing the disk. This results in snapshots that are still compatible with small server-types.