### PR TITLE
doc: remove freebsd64 from rescue system list

### DIFF
--- a/docs/builders/hetzner-cloud.mdx
+++ b/docs/builders/hetzner-cloud.mdx
@@ -104,8 +104,7 @@ builder.
 @include 'packer-plugin-sdk/communicator/SSHTemporaryKeyPair-not-required.mdx'
 
 - `rescue` (string) - Enable and boot in to the specified rescue system. This
-  enables simple installation of custom operating systems. `linux64`
-  `linux32` or `freebsd64`
+  enables simple installation of custom operating systems. `linux64` or `linux32`
 
 - `upgrade_server_type` (string) - ID or name of the server type this server should
   be upgraded to, without changing the disk size. Improves building performance.


### PR DESCRIPTION
Hi,

due to `freebsd64` rescue option is not available anymore, it should be removed from list of rescue systems.
See https://www.reddit.com/r/freebsd/comments/wf7h34/hetzner_has_silently_dropped_support_for_freebsd/ for reference.

Kind regards,
Florian