### PR TITLE
docs: add example for plugin

### DIFF
--- a/example/build.pkr.hcl
+++ b/example/build.pkr.hcl
@@ -1,40 +1,39 @@
 packer {
   required_plugins {
-    scaffolding = {
-      version = ">=v0.1.0"
-      source  = "github.com/hashicorp/scaffolding"
+    hcloud = {
+      version = ">=v1.0.5"
+      source  = "github.com/hashicorp/hcloud"
     }
   }
 }
 
-source "scaffolding-my-builder" "foo-example" {
-  mock = local.foo
+variable "hcloud_token" {
+  type      = string
+  default   = "${env("HCLOUD_TOKEN")}"
+  sensitive = true
 }
 
-source "scaffolding-my-builder" "bar-example" {
-  mock = local.bar
+source "hcloud" "example" {
+  image       = "ubuntu-22.04"
+  location    = "hel1"
+  server_name = "hcloud-example"
+  server_type = "cx11"
+  snapshot_labels = {
+    app = "hcloud-example"
+  }
+  snapshot_name = "hcloud-example"
+  ssh_username  = "root"
+  token         = var.hcloud_token
 }
 
 build {
-  sources = [
-    "source.scaffolding-my-builder.foo-example",
-  ]
+  sources = ["source.hcloud.example"]
 
-  source "source.scaffolding-my-builder.bar-example" {
-    name = "bar"
+  provisioner "shell" {
+    inline = ["cloud-init status --wait"]
   }
 
-  provisioner "scaffolding-my-provisioner" {
-    only = ["scaffolding-my-builder.foo-example"]
-    mock = "foo: ${local.foo}"
-  }
-
-  provisioner "scaffolding-my-provisioner" {
-    only = ["scaffolding-my-builder.bar"]
-    mock = "bar: ${local.bar}"
-  }
-
-  post-processor "scaffolding-my-post-processor" {
-    mock = "post-processor mock-config"
+  provisioner "shell" {
+    inline = ["echo \"Hello World!\" > /var/log/packer.log"]
   }
 }


### PR DESCRIPTION
Updates the example in `example/build.pkr.hcl` to use the actual plugin instead of the `skaffolding` placeholder it was using before.

This does require a new variable `hcloud_token`/`env("HCLOUD_TOKEN")` which is not set right now in the existing workflow that utilizes the example, but it also looks like the workflow is not called from anywhere.