### PR TITLE
bump go 1.18 to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/packer-plugin-hcloud
 
-go 1.18
+go 1.19
 
 require (
 	github.com/hashicorp/hcl/v2 v2.13.0


### PR DESCRIPTION
- chore(deps): bump hcloud-go
- feat: validate architectures for server types
- feat: only select images with right architecture
- feat: validate unique snapshot description per architecture
- go.mod: bump go version from 1.18 to 1.19
