### PR TITLE
feat: add labels options to server and ssh key

### DIFF
--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -31,18 +31,20 @@ type Config struct {
 
 	PollInterval time.Duration `mapstructure:"poll_interval"`
 
-	ServerName        string       `mapstructure:"server_name"`
-	Location          string       `mapstructure:"location"`
-	ServerType        string       `mapstructure:"server_type"`
-	UpgradeServerType string       `mapstructure:"upgrade_server_type"`
-	Image             string       `mapstructure:"image"`
-	ImageFilter       *imageFilter `mapstructure:"image_filter"`
+	ServerName        string            `mapstructure:"server_name"`
+	Location          string            `mapstructure:"location"`
+	ServerType        string            `mapstructure:"server_type"`
+	ServerLabels      map[string]string `mapstructure:"server_labels"`
+	UpgradeServerType string            `mapstructure:"upgrade_server_type"`
+	Image             string            `mapstructure:"image"`
+	ImageFilter       *imageFilter      `mapstructure:"image_filter"`
 
 	SnapshotName   string            `mapstructure:"snapshot_name"`
 	SnapshotLabels map[string]string `mapstructure:"snapshot_labels"`
 	UserData       string            `mapstructure:"user_data"`
 	UserDataFile   string            `mapstructure:"user_data_file"`
 	SSHKeys        []string          `mapstructure:"ssh_keys"`
+	SSHKeyLabels   map[string]string `mapstructure:"sshkey_labels"`
 	Networks       []int64           `mapstructure:"networks"`
 
 	RescueMode string `mapstructure:"rescue"`

--- a/builder/hcloud/config.hcl2spec.go
+++ b/builder/hcloud/config.hcl2spec.go
@@ -73,6 +73,7 @@ type FlatConfig struct {
 	ServerName                *string           `mapstructure:"server_name" cty:"server_name" hcl:"server_name"`
 	Location                  *string           `mapstructure:"location" cty:"location" hcl:"location"`
 	ServerType                *string           `mapstructure:"server_type" cty:"server_type" hcl:"server_type"`
+	ServerLabels              map[string]string `mapstructure:"server_labels" cty:"server_labels" hcl:"server_labels"`
 	UpgradeServerType         *string           `mapstructure:"upgrade_server_type" cty:"upgrade_server_type" hcl:"upgrade_server_type"`
 	Image                     *string           `mapstructure:"image" cty:"image" hcl:"image"`
 	ImageFilter               *FlatimageFilter  `mapstructure:"image_filter" cty:"image_filter" hcl:"image_filter"`
@@ -81,6 +82,7 @@ type FlatConfig struct {
 	UserData                  *string           `mapstructure:"user_data" cty:"user_data" hcl:"user_data"`
 	UserDataFile              *string           `mapstructure:"user_data_file" cty:"user_data_file" hcl:"user_data_file"`
 	SSHKeys                   []string          `mapstructure:"ssh_keys" cty:"ssh_keys" hcl:"ssh_keys"`
+	SSHKeyLabels              map[string]string `mapstructure:"sshkey_labels" cty:"sshkey_labels" hcl:"sshkey_labels"`
 	Networks                  []int64           `mapstructure:"networks" cty:"networks" hcl:"networks"`
 	RescueMode                *string           `mapstructure:"rescue" cty:"rescue" hcl:"rescue"`
 }
@@ -160,6 +162,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"server_name":                  &hcldec.AttrSpec{Name: "server_name", Type: cty.String, Required: false},
 		"location":                     &hcldec.AttrSpec{Name: "location", Type: cty.String, Required: false},
 		"server_type":                  &hcldec.AttrSpec{Name: "server_type", Type: cty.String, Required: false},
+		"server_labels":                &hcldec.AttrSpec{Name: "server_labels", Type: cty.Map(cty.String), Required: false},
 		"upgrade_server_type":          &hcldec.AttrSpec{Name: "upgrade_server_type", Type: cty.String, Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
 		"image_filter":                 &hcldec.BlockSpec{TypeName: "image_filter", Nested: hcldec.ObjectSpec((*FlatimageFilter)(nil).HCL2Spec())},
@@ -168,6 +171,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":               &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"ssh_keys":                     &hcldec.AttrSpec{Name: "ssh_keys", Type: cty.List(cty.String), Required: false},
+		"sshkey_labels":                &hcldec.AttrSpec{Name: "sshkey_labels", Type: cty.Map(cty.String), Required: false},
 		"networks":                     &hcldec.AttrSpec{Name: "networks", Type: cty.List(cty.Number), Required: false},
 		"rescue":                       &hcldec.AttrSpec{Name: "rescue", Type: cty.String, Required: false},
 	}

--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -82,6 +82,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 		Location:   &hcloud.Location{Name: c.Location},
 		UserData:   userData,
 		Networks:   networks,
+		Labels:     c.ServerLabels,
 	}
 
 	if c.UpgradeServerType != "" {
@@ -89,7 +90,6 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 	}
 
 	serverCreateResult, _, err := client.Server.Create(ctx, serverCreateOpts)
-
 	if err != nil {
 		err := fmt.Errorf("Error creating server: %s", err)
 		state.Put("error", err)
@@ -127,7 +127,6 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 			ServerType:  &hcloud.ServerType{Name: c.UpgradeServerType},
 			UpgradeDisk: false,
 		})
-
 		if err != nil {
 			err := fmt.Errorf("Error changing server-type: %s", err)
 			state.Put("error", err)
@@ -144,7 +143,6 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 
 		ui.Say("Starting server...")
 		serverPoweronAction, _, err := client.Server.Poweron(ctx, serverCreateResult.Server)
-
 		if err != nil {
 			err := fmt.Errorf("Error starting server: %s", err)
 			state.Put("error", err)
@@ -256,7 +254,7 @@ func waitForAction(ctx context.Context, client *hcloud.Client, action *hcloud.Ac
 func getImageWithSelectors(ctx context.Context, client *hcloud.Client, c *Config, serverType *hcloud.ServerType) (*hcloud.Image, error) {
 	var allImages []*hcloud.Image
 
-	var selector = strings.Join(c.ImageFilter.WithSelector, ",")
+	selector := strings.Join(c.ImageFilter.WithSelector, ",")
 	opts := hcloud.ImageListOpts{
 		ListOpts:     hcloud.ListOpts{LabelSelector: selector},
 		Status:       []hcloud.ImageStatus{hcloud.ImageStatusAvailable},

--- a/builder/hcloud/step_create_sshkey.go
+++ b/builder/hcloud/step_create_sshkey.go
@@ -36,6 +36,7 @@ func (s *stepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) mu
 	key, _, err := client.SSHKey.Create(ctx, hcloud.SSHKeyCreateOpts{
 		Name:      name,
 		PublicKey: string(c.Comm.SSHPublicKey),
+		Labels:    c.SSHKeyLabels,
 	})
 	if err != nil {
 		err := fmt.Errorf("Error creating temporary SSH key: %s", err)


### PR DESCRIPTION
Adding labels to the temporary server and ssh key objects which are needed to create the snapshot.

This is needed in some use cases where e.g. packer build stops unexpectedly due to a SIGKILL and cannot shut down properly. In order to realize that the respective server and ssh key are orphaned, labels are needed.


