### PR TITLE
feat: receive repo transfer from hashicorp

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,16 +57,14 @@ when addressing our team. For more reading on our code of conduct, please see th
 
 6. The issue is closed.
 
-
-
 ## Setting up Go
 
 If you have never worked with Go before, you will have to install its
 runtime in order to build packer with the Hetzner Cloud plugin.
 
 1. This project always releases from the latest version of golang.
-[Install go](https://golang.org/doc/install#install) To properly build from
-source, you need to have golang >= 1.20
+   [Install go](https://golang.org/doc/install#install) To properly build from
+   source, you need to have golang >= 1.20
 
 ## Setting up Hetzner Cloud plugin for dev
 
@@ -76,25 +74,24 @@ POSIX-like environments (macOS, Linux, Cygwin, etc.) so you may need to
 adjust them for Windows or other shells.
 
 1. Download the Hetzner Cloud plugin source (and its dependencies) by running
-   `go get github.com/hashicorp/packer-plugin-hcloud`. This will download the source to
-   `$GOPATH/src/github.com/hashicorp/packer-plugin-hcloud`.
+   `go get github.com/hetznercloud/packer-plugin-hcloud`. This will download the source to
+   `$GOPATH/src/github.com/hetznercloud/packer-plugin-hcloud`.
 
-2. When working on the Hetzner Cloud plugin, first `cd $GOPATH/src/github.com/hashicorp/packer-plugin-hcloud`
+2. When working on the Hetzner Cloud plugin, first `cd $GOPATH/src/github.com/hetznercloud/packer-plugin-hcloud`
    so you can run `make dev` and easily access other files. `make dev` will build the packer-plugin-hcloud binary and install it under `$HOME/.packer.d/plugins/`.
 
 3. Make your changes to the Hetzner Cloud plugin source. You can run `make dev` to build and install locally, and `make test` to run unit tests.
    Any compilation errors will be shown when the binaries are rebuilding. If you don't have `make` you can simply run `go build -o packer-plugin-hcloud` from the project root, and `mv packer-plugin-hcloud ~/.packer.d/plugins/packer-plugin-hcloud` to install the plugin.
 
-4. After building the Hetzner Cloud plugin successfully, use the latest version of Packer to build a machine and verify your changes. In the [example folder](https://github.com/hashicorp/packer-plugin-hcloud/blob/main/example) we provide a basic template. Comment out the `packer {}` block to force Packer use the development binary installed in the previous step.
+4. After building the Hetzner Cloud plugin successfully, use the latest version of Packer to build a machine and verify your changes. In the [example folder](https://github.com/hetznercloud/packer-plugin-hcloud/blob/main/example) we provide a basic template. Comment out the `packer {}` block to force Packer use the development binary installed in the previous step.
 
 5. If everything works well and the tests pass, run `go fmt ./...` on your code before
    submitting a pull-request.
 
-
 ### Opening a Pull Request
 
 Thank you for contributing! When you are ready to open a pull-request, you will
-need to [fork the Hetzner Cloud plugin](https://github.com/hashicorp/packer-plugin-hcloud#fork-destination-box), push your
+need to [fork the Hetzner Cloud plugin](https://github.com/hetznercloud/packer-plugin-hcloud#fork-destination-box), push your
 changes to your fork, and then open a pull-request.
 
 For example, my github username is `myuser`, so I would do the following:
@@ -185,7 +182,7 @@ project. After following the steps in "Setting up Go to work on the Hetzner Clou
 
 1. Navigate to the code:
 
-   `cd $GOPATH/src/github.com/hashicorp/packer-plugin-hcloud`
+   `cd $GOPATH/src/github.com/hetznercloud/packer-plugin-hcloud`
 
 2. Add the remote by running:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,14 +4,13 @@ In order to have a good experience with our community, we recommend that you
 read the contributing guidelines for making a PR, and understand the lifecycle
 of a Packer Plugin PR:
 
-https://github.com/hashicorp/packer-plugin-hcloud/blob/main/.github/CONTRIBUTING.md#opening-an-pull-request
+https://github.com/hetznercloud/packer-plugin-hcloud/blob/main/.github/CONTRIBUTING.md#opening-an-pull-request
 
 Describe the change you are making here!
 
-Please include tests. We recommend looking at existing tests as an example. 
+Please include tests. We recommend looking at existing tests as an example.
 
 If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:
 
 Closes #xxx
 Closes #xxx
-

--- a/.github/workflows/build_plugin_binaries.yml
+++ b/.github/workflows/build_plugin_binaries.yml
@@ -12,10 +12,10 @@ jobs:
   build_darwin:
     defaults:
       run:
-        working-directory: ~/go/src/github.com/hashicorp/packer-plugin-hcloud
+        working-directory: ~/go/src/github.com/hetznercloud/packer-plugin-hcloud
     runs-on: ubuntu-latest
     container:
-      image: docker.mirror.hashicorp.services/cimg/go:1.20
+      image: cimg/go:1.20
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: "./.github/actions/build-and-persist-plugin-binary"
@@ -29,10 +29,10 @@ jobs:
   build_freebsd:
     defaults:
       run:
-        working-directory: ~/go/src/github.com/hashicorp/packer-plugin-hcloud
+        working-directory: ~/go/src/github.com/hetznercloud/packer-plugin-hcloud
     runs-on: ubuntu-latest
     container:
-      image: docker.mirror.hashicorp.services/cimg/go:1.20
+      image: cimg/go:1.20
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: "./.github/actions/build-and-persist-plugin-binary"
@@ -50,10 +50,10 @@ jobs:
   build_linux:
     defaults:
       run:
-        working-directory: ~/go/src/github.com/hashicorp/packer-plugin-hcloud
+        working-directory: ~/go/src/github.com/hetznercloud/packer-plugin-hcloud
     runs-on: ubuntu-latest
     container:
-      image: docker.mirror.hashicorp.services/cimg/go:1.20
+      image: cimg/go:1.20
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: "./.github/actions/build-and-persist-plugin-binary"
@@ -75,10 +75,10 @@ jobs:
   build_netbsd:
     defaults:
       run:
-        working-directory: ~/go/src/github.com/hashicorp/packer-plugin-hcloud
+        working-directory: ~/go/src/github.com/hetznercloud/packer-plugin-hcloud
     runs-on: ubuntu-latest
     container:
-      image: docker.mirror.hashicorp.services/cimg/go:1.20
+      image: cimg/go:1.20
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: "./.github/actions/build-and-persist-plugin-binary"
@@ -96,10 +96,10 @@ jobs:
   build_openbsd:
     defaults:
       run:
-        working-directory: ~/go/src/github.com/hashicorp/packer-plugin-hcloud
+        working-directory: ~/go/src/github.com/hetznercloud/packer-plugin-hcloud
     runs-on: ubuntu-latest
     container:
-      image: docker.mirror.hashicorp.services/cimg/go:1.20
+      image: cimg/go:1.20
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: "./.github/actions/build-and-persist-plugin-binary"
@@ -117,10 +117,10 @@ jobs:
   build_solaris:
     defaults:
       run:
-        working-directory: ~/go/src/github.com/hashicorp/packer-plugin-hcloud
+        working-directory: ~/go/src/github.com/hetznercloud/packer-plugin-hcloud
     runs-on: ubuntu-latest
     container:
-      image: docker.mirror.hashicorp.services/cimg/go:1.20
+      image: cimg/go:1.20
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: "./.github/actions/build-and-persist-plugin-binary"
@@ -130,10 +130,10 @@ jobs:
   build_windows:
     defaults:
       run:
-        working-directory: ~/go/src/github.com/hashicorp/packer-plugin-hcloud
+        working-directory: ~/go/src/github.com/hetznercloud/packer-plugin-hcloud
     runs-on: ubuntu-latest
     container:
-      image: docker.mirror.hashicorp.services/cimg/go:1.20
+      image: cimg/go:1.20
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: "./.github/actions/build-and-persist-plugin-binary"

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Notify Release
         uses: ./integration-release-action
         with:
-          integration_identifier: "packer/hashicorp/hcloud"
+          integration_identifier: "packer/hetznercloud/hcloud"
           release_version: ${{ github.event.inputs.version }}
           release_sha: ${{ github.event.inputs.branch }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Notify Release
         uses: ./integration-release-action
         with:
-          integration_identifier: "packer/hashicorp/hcloud"
+          integration_identifier: "packer/hetznercloud/hcloud"
           release_version: ${{ needs.strip-version.outputs.packer-version }}
           release_sha: ${{ github.ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 main
 dist/*
-packer-plugin-scaffolding
+packer-plugin-hcloud
 .docs
 crash.log

--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -26,6 +26,6 @@ $ packer plugins install github.com/hetznercloud/hcloud
 
 #### Builders
 
-- [hcloud](/packer/integrations/hashicorp/hcloud/latest/components/builder/hcloud) - The hcloud builder
+- [hcloud](/packer/integrations/hetznercloud/hcloud/latest/components/builder/hcloud) - The hcloud builder
   lets you create custom images on Hetzner Cloud by launching an instance, provisioning it, then
   export it as an image for later reuse.

--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     hcloud = {
-      source  = "github.com/hashicorp/hcloud"
+      source  = "github.com/hetznercloud/hcloud"
       version = "~> 1"
     }
   }
@@ -19,7 +19,7 @@ packer {
 Alternatively, you can use `packer plugins install` to manage installation of this plugin.
 
 ```sh
-$ packer plugins install github.com/hashicorp/hcloud
+$ packer plugins install github.com/hetznercloud/hcloud
 ```
 
 ### Components

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jooola
+* @hetznercloud/integrations

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Packer Plugin Hcloud
+
 The `Hcloud` multi-component plugin can be used with HashiCorp [Packer](https://www.packer.io)
 to create custom images. For the full list of available features for this plugin see [docs](docs).
 
@@ -20,21 +21,19 @@ packer {
   required_plugins {
     hcloud = {
       version = ">= 1.1.1"
-      source  = "github.com/hashicorp/hcloud"
+      source  = "github.com/hetznercloud/hcloud"
     }
   }
 }
 ```
 
-
 #### Manual installation
 
-You can find pre-built binary releases of the plugin [here](https://github.com/hashicorp/packer-plugin-hcloud/releases).
+You can find pre-built binary releases of the plugin [here](https://github.com/hetznercloud/packer-plugin-hcloud/releases).
 Once you have downloaded the latest archive corresponding to your target OS,
 uncompress it to retrieve the plugin binary file corresponding to your platform.
 To install the plugin, please follow the Packer documentation on
 [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
-
 
 ### From Sources
 
@@ -45,19 +44,17 @@ binary file can be found in the root directory.
 To install the compiled plugin, please follow the official Packer documentation
 on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
 
-
 ### Configuration
 
 For more information on how to configure the plugin, please read the
 documentation located in the [`docs/`](docs) directory.
 
-
 ## Contributing
 
-* If you think you've found a bug in the code or you have a question regarding
+- If you think you've found a bug in the code or you have a question regarding
   the usage of this software, please reach out to us by opening an issue in
   this GitHub repository.
-* Contributions to this project are welcome: if you want to add a feature or a
+- Contributions to this project are welcome: if you want to add a feature or a
   fix a bug, please do so by opening a Pull Request in this GitHub repository.
   In case of feature contribution, we kindly ask you to open an issue to
   discuss it beforehand.

--- a/builder/hcloud/builder.go
+++ b/builder/hcloud/builder.go
@@ -14,7 +14,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 
-	"github.com/hashicorp/packer-plugin-hcloud/version"
+	"github.com/hetznercloud/packer-plugin-hcloud/version"
 )
 
 // The unique id for the builder

--- a/builder/hcloud/builder_acc_test.go
+++ b/builder/hcloud/builder_acc_test.go
@@ -35,7 +35,7 @@ func TestBuilderAcc_basic(t *testing.T) {
 const testBuilderAccBasic = `
 {
 	"builders": [{
-		"type": "test",
+		"type": "hcloud",
 		"location": "nbg1",
 		"server_type": "cx11",
 		"image": "ubuntu-22.04",

--- a/builder/hcloud/builder_acc_test.go
+++ b/builder/hcloud/builder_acc_test.go
@@ -13,12 +13,14 @@ import (
 )
 
 func TestBuilderAcc_basic(t *testing.T) {
-	if v := os.Getenv("HCLOUD_TOKEN"); v == "" {
-		t.Skip("HCLOUD_TOKEN must be set for acceptance tests")
-	}
-
 	testCase := &acctest.PluginTestCase{
-		Name:     "hcloud_basic_test",
+		Name: "hcloud_basic_test",
+		Setup: func() error {
+			if v := os.Getenv("HCLOUD_TOKEN"); v == "" {
+				return fmt.Errorf("HCLOUD_TOKEN must be set for acceptance tests")
+			}
+			return nil
+		},
 		Template: testBuilderAccBasic,
 		Check: func(buildCommand *exec.Cmd, logfile string) error {
 			if buildCommand.ProcessState != nil {

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,6 @@ $ packer plugins install github.com/hetznercloud/hcloud
 
 #### Builders
 
-- [hcloud](/packer/integrations/hashicorp/hcloud/latest/components/builder/hcloud) - The hcloud builder
+- [hcloud](/packer/integrations/hetznercloud/hcloud/latest/components/builder/hcloud) - The hcloud builder
   lets you create custom images on Hetzner Cloud by launching an instance, provisioning it, then
   export it as an image for later reuse.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     hcloud = {
-      source  = "github.com/hashicorp/hcloud"
+      source  = "github.com/hetznercloud/hcloud"
       version = "~> 1"
     }
   }
@@ -19,7 +19,7 @@ packer {
 Alternatively, you can use `packer plugins install` to manage installation of this plugin.
 
 ```sh
-$ packer plugins install github.com/hashicorp/hcloud
+$ packer plugins install github.com/hetznercloud/hcloud
 ```
 
 ### Components

--- a/example/build.pkr.hcl
+++ b/example/build.pkr.hcl
@@ -5,7 +5,7 @@ packer {
   required_plugins {
     hcloud = {
       version = ">=1.1.0"
-      source  = "github.com/hashicorp/hcloud"
+      source  = "github.com/hetznercloud/hcloud"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/packer-plugin-hcloud
+module github.com/hetznercloud/packer-plugin-hcloud
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hashicorp/packer-plugin-hcloud/version"
+	"github.com/hetznercloud/packer-plugin-hcloud/builder/hcloud"
+	"github.com/hetznercloud/packer-plugin-hcloud/version"
 
-	hcloud "github.com/hashicorp/packer-plugin-hcloud/builder/hcloud"
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
 )
 


### PR DESCRIPTION
Continuation work after #93

This pull request makes the initial changes to transfer packer-plugin-hcloud to the Hetzner Cloud GitHub organization. This mainly consists of reference changes from hashicorp to hetznercloud.

