### PR TITLE
ci: use github draft releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ jobs:
           token: ${{ secrets.HCLOUD_BOT_TOKEN }}
           release-type: go
           package-name: packer-plugin-hcloud
+          draft: true
 
           extra-files: |
             version/version.go


### PR DESCRIPTION
This allows us to tweak the release before publishing, e.g. if we
publish a prerelease, we don't want it to be marked as latest, and want
to mark it as prerelease.