### PR TITLE
ci: ensure release-notify has access to metadata.hcl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
       - uses: hashicorp/integration-release-action@main


### PR DESCRIPTION
Make sure the hashicorp/integration-release-action has access to the metadata.hcl file.

https://github.com/hetznercloud/packer-plugin-hcloud/actions/runs/6784123847/job/18473506517

Release-As: 1.2.0

BEGIN_COMMIT_OVERRIDE
feat: transfer the packer plugin to the `hetznercloud` organization

Release-As: 1.2.0
END_COMMIT_OVERRIDE