### PR TITLE
feat: add HCP packer support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,6 @@ jobs:
         with:
           version: "1.10.0" # renovate: datasource=github-releases depName=hashicorp/packer extractVersion=v(?<version>.+)
 
-      - run: packer init .
-      - run: packer validate .
-      - run: packer build .
+      - run: packer init build.pkr.hcl
+      - run: packer validate build.pkr.hcl
+      - run: packer build build.pkr.hcl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,3 +40,9 @@ linters:
     - unparam
     - unused
     - whitespace
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl

--- a/builder/hcloud/artifact_test.go
+++ b/builder/hcloud/artifact_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestArtifact_Impl(t *testing.T) {
@@ -57,4 +60,39 @@ func TestArtifactState_StateData(t *testing.T) {
 	if result != nil {
 		t.Fatalf("Bad: State should be nil for nil StateData")
 	}
+}
+
+func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
+	artifact := &Artifact{
+		snapshotId:   167438588,
+		snapshotName: "test-image",
+		StateData: map[string]interface{}{
+			"source_image":    "ubuntu-24.04",
+			"source_image_id": int64(161547269),
+			"region":          "hel1",
+			"server_type":     "cpx11",
+		},
+	}
+
+	result := artifact.State(registryimage.ArtifactStateURI)
+	if result == nil {
+		t.Fatalf("Bad: HCP Packer registry image data was nil")
+	}
+
+	// check for proper decoding of result into slice of registryimage.Image
+	var image registryimage.Image
+	err := mapstructure.Decode(result, &image)
+	if err != nil {
+		t.Errorf("Bad: unexpected error when trying to decode state into registryimage.Image %v", err)
+	}
+
+	assert.Equal(t, registryimage.Image{
+		ImageID:       "167438588",
+		ProviderName:  "hetznercloud",
+		SourceImageID: "161547269",
+		Labels: map[string]string{
+			"source_image": "ubuntu-24.04",
+			"server_type":  "cpx11",
+		},
+	}, image)
 }

--- a/builder/hcloud/artifact_test.go
+++ b/builder/hcloud/artifact_test.go
@@ -10,6 +10,7 @@ import (
 	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestArtifact_Impl(t *testing.T) {
@@ -75,15 +76,11 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 	}
 
 	result := artifact.State(registryimage.ArtifactStateURI)
-	if result == nil {
-		t.Fatalf("Bad: HCP Packer registry image data was nil")
-	}
+	require.NotNil(t, result)
 
-	// check for proper decoding of result into slice of registryimage.Image
 	var image registryimage.Image
-	err := mapstructure.Decode(result, &image)
-	if err != nil {
-		t.Errorf("Bad: unexpected error when trying to decode state into registryimage.Image %v", err)
+	if err := mapstructure.Decode(result, &image); err != nil {
+		t.Errorf("unexpected error when trying to decode state into registryimage.Image %v", err)
 	}
 
 	assert.Equal(t, registryimage.Image{

--- a/builder/hcloud/artifact_test.go
+++ b/builder/hcloud/artifact_test.go
@@ -70,7 +70,6 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 		StateData: map[string]interface{}{
 			"source_image":    "ubuntu-24.04",
 			"source_image_id": int64(161547269),
-			"region":          "hel1",
 			"server_type":     "cpx11",
 		},
 	}

--- a/builder/hcloud/builder.go
+++ b/builder/hcloud/builder.go
@@ -106,7 +106,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			"generated_data":  state.Get(StateGeneratedData),
 			"source_image":    b.config.Image,
 			"source_image_id": state.Get(StateSourceImageID),
-			"region":          b.config.Location,
 			"server_type":     b.config.ServerType,
 		},
 	}

--- a/builder/hcloud/builder.go
+++ b/builder/hcloud/builder.go
@@ -102,7 +102,13 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		snapshotName: state.Get(StateSnapshotName).(string),
 		snapshotId:   state.Get(StateSnapshotID).(int64),
 		hcloudClient: b.hcloudClient,
-		StateData:    map[string]interface{}{"generated_data": state.Get(StateGeneratedData)},
+		StateData: map[string]interface{}{
+			"generated_data":  state.Get(StateGeneratedData),
+			"source_image":    b.config.Image,
+			"source_image_id": state.Get(StateSourceImageID),
+			"region":          b.config.Location,
+			"server_type":     b.config.ServerType,
+		},
 	}
 
 	return artifact, nil

--- a/builder/hcloud/state.go
+++ b/builder/hcloud/state.go
@@ -25,6 +25,8 @@ const (
 	StateSnapshotIDOld = "snapshot_id_old"
 	StateSnapshotName  = "snapshot_name"
 	StateSSHKeyID      = "ssh_key_id"
+
+	StateSourceImageID = "source_image_id"
 )
 
 func UnpackState(state multistep.StateBag) (*Config, packersdk.Ui, *hcloud.Client) {

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
@@ -21,6 +22,7 @@ func TestStepCreateServer(t *testing.T) {
 			Step: &stepCreateServer{},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
@@ -28,12 +30,17 @@ func TestStepCreateServer(t *testing.T) {
 						"ssh_key": { "id": 1 }
 					}`,
 				},
+				{"GET", "/images?architecture=x86&include_deprecated=true&name=debian-12", nil,
+					200, `{
+						"images": [{ "id": 114690387, "name": "debian-12", "description": "Debian 12", "architecture": "x86" }]
+					}`,
+				},
 				{"POST", "/servers",
 					func(t *testing.T, r *http.Request, body []byte) {
 						payload := schema.ServerCreateRequest{}
 						assert.NoError(t, json.Unmarshal(body, &payload))
 						assert.Equal(t, "dummy-server", payload.Name)
-						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, int64(114690387), int64(payload.Image.(float64)))
 						assert.Equal(t, "nbg1", payload.Location)
 						assert.Equal(t, "cpx11", payload.ServerType)
 						assert.Nil(t, payload.Networks)
@@ -76,6 +83,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
@@ -83,12 +91,17 @@ func TestStepCreateServer(t *testing.T) {
 						"ssh_key": { "id": 1 }
 					}`,
 				},
+				{"GET", "/images?architecture=x86&include_deprecated=true&name=debian-12", nil,
+					200, `{
+						"images": [{ "id": 114690387, "name": "debian-12", "description": "Debian 12", "architecture": "x86" }]
+					}`,
+				},
 				{"POST", "/servers",
 					func(t *testing.T, r *http.Request, body []byte) {
 						payload := schema.ServerCreateRequest{}
 						assert.NoError(t, json.Unmarshal(body, &payload))
 						assert.Equal(t, "dummy-server", payload.Name)
-						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, int64(114690387), int64(payload.Image.(float64)))
 						assert.Equal(t, "nbg1", payload.Location)
 						assert.Equal(t, "cpx11", payload.ServerType)
 						assert.Equal(t, []int64{12}, payload.Networks)
@@ -132,11 +145,17 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
 					200, `{
 						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/images?architecture=x86&include_deprecated=true&name=debian-12", nil,
+					200, `{
+						"images": [{ "id": 114690387, "name": "debian-12", "description": "Debian 12", "architecture": "x86" }]
 					}`,
 				},
 				{"GET", "/primary_ips?name=permanent-packer-ipv4", nil,
@@ -168,7 +187,7 @@ func TestStepCreateServer(t *testing.T) {
 						payload := schema.ServerCreateRequest{}
 						assert.NoError(t, json.Unmarshal(body, &payload))
 						assert.Equal(t, "dummy-server", payload.Name)
-						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, int64(114690387), int64(payload.Image.(float64)))
 						assert.Equal(t, "nbg1", payload.Location)
 						assert.Equal(t, "cpx11", payload.ServerType)
 						assert.Nil(t, payload.Networks)
@@ -214,11 +233,17 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
 					200, `{
 						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/images?architecture=x86&include_deprecated=true&name=debian-12", nil,
+					200, `{
+						"images": [{ "id": 114690387, "name": "debian-12", "description": "Debian 12", "architecture": "x86" }]
 					}`,
 				},
 				{"GET", "/primary_ips?name=127.0.0.1", nil,
@@ -254,7 +279,7 @@ func TestStepCreateServer(t *testing.T) {
 						payload := schema.ServerCreateRequest{}
 						assert.NoError(t, json.Unmarshal(body, &payload))
 						assert.Equal(t, "dummy-server", payload.Name)
-						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, int64(114690387), int64(payload.Image.(float64)))
 						assert.Equal(t, "nbg1", payload.Location)
 						assert.Equal(t, "cpx11", payload.ServerType)
 						assert.Nil(t, payload.Networks)
@@ -299,11 +324,17 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
 					200, `{
 						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/images?architecture=x86&include_deprecated=true&name=debian-12", nil,
+					200, `{
+						"images": [{ "id": 114690387, "name": "debian-12", "description": "Debian 12", "architecture": "x86" }]
 					}`,
 				},
 				{"GET", "/primary_ips?name=127.0.0.1", nil,
@@ -329,11 +360,17 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
 					200, `{
 						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/images?architecture=x86&include_deprecated=true&name=debian-12", nil,
+					200, `{
+						"images": [{ "id": 114690387, "name": "debian-12", "description": "Debian 12", "architecture": "x86" }]
 					}`,
 				},
 				{"GET", "/primary_ips?name=127.0.0.1", nil,
@@ -359,11 +396,17 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
 					200, `{
 						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/images?architecture=x86&include_deprecated=true&name=debian-12", nil,
+					200, `{
+						"images": [{ "id": 114690387, "name": "debian-12", "description": "Debian 12", "architecture": "x86" }]
 					}`,
 				},
 				{"GET", "/primary_ips?name=127.0.0.1", nil,
@@ -389,11 +432,17 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
 					200, `{
 						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/images?architecture=x86&include_deprecated=true&name=debian-12", nil,
+					200, `{
+						"images": [{ "id": 114690387, "name": "debian-12", "description": "Debian 12", "architecture": "x86" }]
 					}`,
 				},
 				{"GET", "/primary_ips?name=127.0.0.1", nil,

--- a/builder/hcloud/step_test.go
+++ b/builder/hcloud/step_test.go
@@ -86,7 +86,7 @@ func NewTestServer(t *testing.T, requests []Request) *httptest.Server {
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if testing.Verbose() {
-			t.Logf("request %d: %s %s\n", index, r.Method, r.URL.Path)
+			t.Logf("request %d: %s %s\n", index, r.Method, r.RequestURI)
 		}
 
 		if index >= len(requests) {

--- a/example/build_hcp.pkr.hcl
+++ b/example/build_hcp.pkr.hcl
@@ -1,0 +1,53 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+packer {
+  required_plugins {
+    hcloud = {
+      source  = "github.com/hetznercloud/hcloud"
+      version = ">=1.1.0"
+    }
+  }
+}
+
+variable "hcloud_token" {
+  type      = string
+  sensitive = true
+  default   = "${env("HCLOUD_TOKEN")}"
+}
+
+source "hcloud" "example" {
+  token = var.hcloud_token
+
+  location    = "hel1"
+  image       = "ubuntu-24.04"
+  server_type = "cpx11"
+  server_name = "hcloud-example"
+
+  ssh_username = "root"
+
+  snapshot_name = "hcloud-example"
+  snapshot_labels = {
+    app = "hcloud-example"
+  }
+}
+
+build {
+  hcp_packer_registry {
+    description = "A nice test description"
+    bucket_name = "hcloud-hcp-test"
+    bucket_labels = {
+      "packer version" = packer.version
+    }
+  }
+
+  sources = ["source.hcloud.example"]
+
+  provisioner "shell" {
+    inline = ["cloud-init status --wait || test $? -eq 2"]
+  }
+
+  provisioner "shell" {
+    inline = ["echo 'Hello World!' > /var/log/packer.log"]
+  }
+}


### PR DESCRIPTION
This pull request adds support for the HCP Packer registry by including the necessary metadata in the image state. 

For more details, see: https://developer.hashicorp.com/packer/docs/plugins/creation/hcp-support

Continuation of #91 after accidentally closing the PR.
