### PR TITLE
ci: run go mod tidy on renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>hetznercloud/.github//renovate/default"]
+  "extends": ["github>hetznercloud/.github//renovate/default"],
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
Automatically run go mo tidy when updating dependencies. This reduces manual actions; for example here: https://github.com/hetznercloud/packer-plugin-hcloud/pull/131