### PR TITLE
refactor: add state helpers

### DIFF
--- a/builder/hcloud/builder.go
+++ b/builder/hcloud/builder.go
@@ -47,10 +47,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	b.hcloudClient = hcloud.NewClient(opts...)
 	// Set up the state
 	state := new(multistep.BasicStateBag)
-	state.Put("config", &b.config)
-	state.Put("hcloudClient", b.hcloudClient)
-	state.Put("hook", hook)
-	state.Put("ui", ui)
+	state.Put(StateConfig, &b.config)
+	state.Put(StateHCloudClient, b.hcloudClient)
+	state.Put(StateHook, hook)
+	state.Put(StateUI, ui)
 
 	// Build the steps
 	steps := []multistep.Step{
@@ -86,19 +86,19 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	b.runner = commonsteps.NewRunner(steps, b.config.PackerConfig, ui)
 	b.runner.Run(ctx, state)
 	// If there was an error, return that
-	if rawErr, ok := state.GetOk("error"); ok {
+	if rawErr, ok := state.GetOk(StateError); ok {
 		return nil, rawErr.(error)
 	}
 
-	if _, ok := state.GetOk("snapshot_name"); !ok {
+	if _, ok := state.GetOk(StateSnapshotName); !ok {
 		return nil, nil
 	}
 
 	artifact := &Artifact{
-		snapshotName: state.Get("snapshot_name").(string),
-		snapshotId:   state.Get("snapshot_id").(int64),
+		snapshotName: state.Get(StateSnapshotName).(string),
+		snapshotId:   state.Get(StateSnapshotID).(int64),
 		hcloudClient: b.hcloudClient,
-		StateData:    map[string]interface{}{"generated_data": state.Get("generated_data")},
+		StateData:    map[string]interface{}{"generated_data": state.Get(StateGeneratedData)},
 	}
 
 	return artifact, nil

--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -156,5 +156,5 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 }
 
 func getServerIP(state multistep.StateBag) (string, error) {
-	return state.Get("server_ip").(string), nil
+	return state.Get(StateServerIP).(string), nil
 }

--- a/builder/hcloud/helper.go
+++ b/builder/hcloud/helper.go
@@ -15,7 +15,7 @@ func errorHandler(state multistep.StateBag, ui packersdk.Ui, prefix string, err 
 		wrappedError = fmt.Errorf("%s: %w", prefix, err)
 	}
 
-	state.Put("error", wrappedError)
+	state.Put(StateError, wrappedError)
 	ui.Error(wrappedError.Error())
 	return multistep.ActionHalt
 }

--- a/builder/hcloud/state.go
+++ b/builder/hcloud/state.go
@@ -3,6 +3,7 @@ package hcloud
 import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/builder/hcloud/state.go
+++ b/builder/hcloud/state.go
@@ -1,0 +1,35 @@
+package hcloud
+
+import (
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// State keys to put or get data from the state
+const (
+	StateConfig = "config"
+	StateHook   = "hook"
+	StateUI     = "ui"
+	StateError  = "error"
+
+	StateHCloudClient = "hcloud_client"
+
+	StateGeneratedData = "generated_data"
+	StateInstanceID    = "instance_id"
+	StateServerID      = "server_id"
+	StateServerIP      = "server_ip"
+	StateServerType    = "server_type"
+	StateSnapshotID    = "snapshot_id"
+	StateSnapshotIDOld = "snapshot_id_old"
+	StateSnapshotName  = "snapshot_name"
+	StateSSHKeyID      = "ssh_key_id"
+)
+
+func UnpackState(state multistep.StateBag) (*Config, packersdk.Ui, *hcloud.Client) {
+	config := state.Get(StateConfig).(*Config)
+	ui := state.Get(StateUI).(packersdk.Ui)
+	client := state.Get(StateHCloudClient).(*hcloud.Client)
+
+	return config, ui, client
+}

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -111,13 +111,13 @@ func TestStepCreateServer(t *testing.T) {
 			config.Networks = tc.config.Networks
 
 			if testing.Verbose() {
-				state.Put("ui", packersdk.TestUi(t))
+				state.Put(StateUI, packersdk.TestUi(t))
 			} else {
 				// do not output to stdout or console
-				state.Put("ui", &packersdk.MockUi{})
+				state.Put(StateUI, &packersdk.MockUi{})
 			}
-			state.Put("config", &config)
-			state.Put("ssh_key_id", int64(1))
+			state.Put(StateConfig, &config)
+			state.Put(StateSSHKeyID, int64(1))
 
 			if action := step.Run(context.Background(), state); action != tc.wantAction {
 				t.Errorf("step.Run: want: %v; got: %v", tc.wantAction, action)
@@ -197,7 +197,7 @@ func setupStepCreateServer(
 
 	state := multistep.BasicStateBag{}
 	client := hcloud.NewClient(hcloud.WithEndpoint(ts.URL))
-	state.Put("hcloudClient", client)
+	state.Put(StateHCloudClient, client)
 
 	teardown := func() {
 		ts.Close()

--- a/builder/hcloud/step_create_snapshot_test.go
+++ b/builder/hcloud/step_create_snapshot_test.go
@@ -74,15 +74,15 @@ func TestStepCreateSnapshot(t *testing.T) {
 			step := &stepCreateSnapshot{}
 			config := Config{SnapshotName: snapName}
 			if testing.Verbose() {
-				state.Put("ui", packersdk.TestUi(t))
+				state.Put(StateUI, packersdk.TestUi(t))
 			} else {
 				// do not output to stdout or console
-				state.Put("ui", &packersdk.MockUi{})
+				state.Put(StateUI, &packersdk.MockUi{})
 			}
-			state.Put("config", &config)
-			state.Put("server_id", serverID)
+			state.Put(StateConfig, &config)
+			state.Put(StateServerID, serverID)
 			if tc.oldSnapID != 0 {
-				state.Put(OldSnapshotID, tc.oldSnapID)
+				state.Put(StateSnapshotIDOld, tc.oldSnapID)
 			}
 
 			if action := step.Run(context.Background(), state); action != tc.wantAction {
@@ -169,7 +169,7 @@ func setupStepCreateSnapshot(
 
 	state := multistep.BasicStateBag{}
 	client := hcloud.NewClient(hcloud.WithEndpoint(ts.URL))
-	state.Put("hcloudClient", client)
+	state.Put(StateHCloudClient, client)
 
 	teardown := func() {
 		ts.Close()

--- a/builder/hcloud/step_pre_validate_test.go
+++ b/builder/hcloud/step_pre_validate_test.go
@@ -55,17 +55,17 @@ func TestStepPreValidate(t *testing.T) {
 			defer teardown()
 
 			if testing.Verbose() {
-				state.Put("ui", packersdk.TestUi(t))
+				state.Put(StateUI, packersdk.TestUi(t))
 			} else {
 				// do not output to stdout or console
-				state.Put("ui", &packersdk.MockUi{})
+				state.Put(StateUI, &packersdk.MockUi{})
 			}
 
 			if action := tc.step.Run(context.Background(), state); action != tc.wantAction {
 				t.Errorf("step.Run: want: %v; got: %v", tc.wantAction, action)
 			}
 
-			oldSnap, found := state.GetOk(OldSnapshotID)
+			oldSnap, found := state.GetOk(StateSnapshotIDOld)
 			if found {
 				oldSnapID := oldSnap.(int64)
 				if tc.wantOldSnapID == 0 {
@@ -147,12 +147,12 @@ func setupStepPreValidate(errors chan<- error, fakeSnapNames []string) (*multist
 	state := multistep.BasicStateBag{}
 
 	client := hcloud.NewClient(hcloud.WithEndpoint(ts.URL), hcloud.WithDebugWriter(os.Stderr))
-	state.Put("hcloudClient", client)
+	state.Put(StateHCloudClient, client)
 
 	config := &Config{
 		ServerType: "cx11",
 	}
-	state.Put("config", config)
+	state.Put(StateConfig, config)
 
 	teardown := func() {
 		ts.Close()

--- a/builder/hcloud/step_shutdown_server.go
+++ b/builder/hcloud/step_shutdown_server.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
@@ -16,14 +15,13 @@ type stepShutdownServer struct{}
 
 //nolint:gosimple,goimports
 func (s *stepShutdownServer) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	client := state.Get("hcloudClient").(*hcloud.Client)
-	ui := state.Get("ui").(packersdk.Ui)
-	serverID := state.Get("server_id").(int64)
+	_, ui, client := UnpackState(state)
+
+	serverID := state.Get(StateServerID).(int64)
 
 	ui.Say("Shutting down server...")
 
 	action, _, err := client.Server.Shutdown(ctx, &hcloud.Server{ID: serverID})
-
 	if err != nil {
 		return errorHandler(state, ui, "Error stopping server", err)
 	}


### PR DESCRIPTION
- Use constants for the different state keys
- Add helper to unpack common state objects (config, ui, client).