### PR TITLE
feat: use existing IP for server create

### DIFF
--- a/.web-docs/components/builder/hcloud/README.md
+++ b/.web-docs/components/builder/hcloud/README.md
@@ -131,8 +131,11 @@ builder.
 - `networks` (array of integers) - List of Network IDs which should be
   attached to the server private network interface at creation time.
 
-- `public_ipv4` (string) - ID or IP address of a pre-allocated Hetzner
-  Primary IPv4 address or to use for the created server.
+- `public_ipv4` (string) - ID, name or IP address of a pre-allocated Hetzner
+  Primary IPv4 address to use for the created server.
+
+- `public_ipv6` (string) - ID, name or IP address of a pre-allocated Hetzner
+  Primary IPv6 address to use for the created server.
 
 ## Basic Example
 

--- a/.web-docs/components/builder/hcloud/README.md
+++ b/.web-docs/components/builder/hcloud/README.md
@@ -131,6 +131,9 @@ builder.
 - `networks` (array of integers) - List of Network IDs which should be
   attached to the server private network interface at creation time.
 
+- `public_ipv4` (string) - Pre-allocated Hetzner PrimaryIPv4 address
+  to use for the created server.
+
 ## Basic Example
 
 Here is a basic example. It is completely valid as soon as you enter your own

--- a/.web-docs/components/builder/hcloud/README.md
+++ b/.web-docs/components/builder/hcloud/README.md
@@ -131,8 +131,8 @@ builder.
 - `networks` (array of integers) - List of Network IDs which should be
   attached to the server private network interface at creation time.
 
-- `public_ipv4` (string) - Pre-allocated Hetzner PrimaryIPv4 address
-  to use for the created server.
+- `public_ipv4` (string) - ID or IP address of a pre-allocated Hetzner
+  Primary IPv4 address or to use for the created server.
 
 ## Basic Example
 

--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	SSHKeys        []string          `mapstructure:"ssh_keys"`
 	SSHKeysLabels  map[string]string `mapstructure:"ssh_keys_labels"`
 	Networks       []int64           `mapstructure:"networks"`
-	PublicIPv4     string            `mapstructure:"public_ipv4"`
+	PublicIPv4     string            `mapstructure:"public_ipv4_address"`
 
 	RescueMode string `mapstructure:"rescue"`
 

--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	SSHKeysLabels  map[string]string `mapstructure:"ssh_keys_labels"`
 	Networks       []int64           `mapstructure:"networks"`
 	PublicIPv4     string            `mapstructure:"public_ipv4"`
+	PublicIPv6     string            `mapstructure:"public_ipv6"`
 
 	RescueMode string `mapstructure:"rescue"`
 

--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	SSHKeys        []string          `mapstructure:"ssh_keys"`
 	SSHKeysLabels  map[string]string `mapstructure:"ssh_keys_labels"`
 	Networks       []int64           `mapstructure:"networks"`
-	PublicIPv4     string            `mapstructure:"public_ipv4_address"`
+	PublicIPv4     string            `mapstructure:"public_ipv4"`
 
 	RescueMode string `mapstructure:"rescue"`
 

--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	SSHKeys        []string          `mapstructure:"ssh_keys"`
 	SSHKeysLabels  map[string]string `mapstructure:"ssh_keys_labels"`
 	Networks       []int64           `mapstructure:"networks"`
+	PublicIPv4     string            `mapstructure:"public_ipv4"`
 
 	RescueMode string `mapstructure:"rescue"`
 

--- a/builder/hcloud/config.hcl2spec.go
+++ b/builder/hcloud/config.hcl2spec.go
@@ -84,7 +84,7 @@ type FlatConfig struct {
 	SSHKeys                   []string          `mapstructure:"ssh_keys" cty:"ssh_keys" hcl:"ssh_keys"`
 	SSHKeysLabels             map[string]string `mapstructure:"ssh_keys_labels" cty:"ssh_keys_labels" hcl:"ssh_keys_labels"`
 	Networks                  []int64           `mapstructure:"networks" cty:"networks" hcl:"networks"`
-	PublicIPv4                *string           `mapstructure:"public_ipv4_address" cty:"public_ipv4_address" hcl:"public_ipv4_address"`
+	PublicIPv4                *string           `mapstructure:"public_ipv4" cty:"public_ipv4" hcl:"public_ipv4"`
 	RescueMode                *string           `mapstructure:"rescue" cty:"rescue" hcl:"rescue"`
 }
 
@@ -174,7 +174,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_keys":                     &hcldec.AttrSpec{Name: "ssh_keys", Type: cty.List(cty.String), Required: false},
 		"ssh_keys_labels":              &hcldec.AttrSpec{Name: "ssh_keys_labels", Type: cty.Map(cty.String), Required: false},
 		"networks":                     &hcldec.AttrSpec{Name: "networks", Type: cty.List(cty.Number), Required: false},
-		"public_ipv4_address":          &hcldec.AttrSpec{Name: "public_ipv4_address", Type: cty.String, Required: false},
+		"public_ipv4":                  &hcldec.AttrSpec{Name: "public_ipv4", Type: cty.String, Required: false},
 		"rescue":                       &hcldec.AttrSpec{Name: "rescue", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/hcloud/config.hcl2spec.go
+++ b/builder/hcloud/config.hcl2spec.go
@@ -84,7 +84,7 @@ type FlatConfig struct {
 	SSHKeys                   []string          `mapstructure:"ssh_keys" cty:"ssh_keys" hcl:"ssh_keys"`
 	SSHKeysLabels             map[string]string `mapstructure:"ssh_keys_labels" cty:"ssh_keys_labels" hcl:"ssh_keys_labels"`
 	Networks                  []int64           `mapstructure:"networks" cty:"networks" hcl:"networks"`
-	PublicIPv4                *string           `mapstructure:"public_ipv4" cty:"public_ipv4" hcl:"public_ipv4"`
+	PublicIPv4                *string           `mapstructure:"public_ipv4_address" cty:"public_ipv4_address" hcl:"public_ipv4_address"`
 	RescueMode                *string           `mapstructure:"rescue" cty:"rescue" hcl:"rescue"`
 }
 
@@ -174,7 +174,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_keys":                     &hcldec.AttrSpec{Name: "ssh_keys", Type: cty.List(cty.String), Required: false},
 		"ssh_keys_labels":              &hcldec.AttrSpec{Name: "ssh_keys_labels", Type: cty.Map(cty.String), Required: false},
 		"networks":                     &hcldec.AttrSpec{Name: "networks", Type: cty.List(cty.Number), Required: false},
-		"public_ipv4":                  &hcldec.AttrSpec{Name: "public_ipv4", Type: cty.String, Required: false},
+		"public_ipv4_address":          &hcldec.AttrSpec{Name: "public_ipv4_address", Type: cty.String, Required: false},
 		"rescue":                       &hcldec.AttrSpec{Name: "rescue", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/hcloud/config.hcl2spec.go
+++ b/builder/hcloud/config.hcl2spec.go
@@ -85,6 +85,7 @@ type FlatConfig struct {
 	SSHKeysLabels             map[string]string `mapstructure:"ssh_keys_labels" cty:"ssh_keys_labels" hcl:"ssh_keys_labels"`
 	Networks                  []int64           `mapstructure:"networks" cty:"networks" hcl:"networks"`
 	PublicIPv4                *string           `mapstructure:"public_ipv4" cty:"public_ipv4" hcl:"public_ipv4"`
+	PublicIPv6                *string           `mapstructure:"public_ipv6" cty:"public_ipv6" hcl:"public_ipv6"`
 	RescueMode                *string           `mapstructure:"rescue" cty:"rescue" hcl:"rescue"`
 }
 
@@ -175,6 +176,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_keys_labels":              &hcldec.AttrSpec{Name: "ssh_keys_labels", Type: cty.Map(cty.String), Required: false},
 		"networks":                     &hcldec.AttrSpec{Name: "networks", Type: cty.List(cty.Number), Required: false},
 		"public_ipv4":                  &hcldec.AttrSpec{Name: "public_ipv4", Type: cty.String, Required: false},
+		"public_ipv6":                  &hcldec.AttrSpec{Name: "public_ipv6", Type: cty.String, Required: false},
 		"rescue":                       &hcldec.AttrSpec{Name: "rescue", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/hcloud/config.hcl2spec.go
+++ b/builder/hcloud/config.hcl2spec.go
@@ -84,6 +84,7 @@ type FlatConfig struct {
 	SSHKeys                   []string          `mapstructure:"ssh_keys" cty:"ssh_keys" hcl:"ssh_keys"`
 	SSHKeysLabels             map[string]string `mapstructure:"ssh_keys_labels" cty:"ssh_keys_labels" hcl:"ssh_keys_labels"`
 	Networks                  []int64           `mapstructure:"networks" cty:"networks" hcl:"networks"`
+	PublicIPv4                *string           `mapstructure:"public_ipv4" cty:"public_ipv4" hcl:"public_ipv4"`
 	RescueMode                *string           `mapstructure:"rescue" cty:"rescue" hcl:"rescue"`
 }
 
@@ -173,6 +174,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_keys":                     &hcldec.AttrSpec{Name: "ssh_keys", Type: cty.List(cty.String), Required: false},
 		"ssh_keys_labels":              &hcldec.AttrSpec{Name: "ssh_keys_labels", Type: cty.Map(cty.String), Required: false},
 		"networks":                     &hcldec.AttrSpec{Name: "networks", Type: cty.List(cty.Number), Required: false},
+		"public_ipv4":                  &hcldec.AttrSpec{Name: "public_ipv4", Type: cty.String, Required: false},
 		"rescue":                       &hcldec.AttrSpec{Name: "rescue", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -81,7 +81,10 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 	if c.PublicIPv4 != "" {
 		publicIPv4, _, err := client.PrimaryIP.GetByIP(ctx, c.PublicIPv4)
 		if err != nil {
-			return errorHandler(state, ui, "Could not find PublicIPv4", err)
+			return errorHandler(state, ui, "Failed to get specified Public IPv4 address", err)
+		}
+		if publicIPv4 == nil {
+		  return errorHandler(state, ui, "", fmt.Errorf("Could not find PublicIPv4"))
 		}
 		publicNetOpts := hcloud.ServerCreatePublicNet{
 			EnableIPv4: true,

--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -93,7 +93,13 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 				return errorHandler(state, ui, fmt.Sprintf("Could not fetch primary ip '%s'", c.PublicIPv4), err)
 			}
 			if publicIPv4 == nil {
-				return errorHandler(state, ui, "", fmt.Errorf("Could not find primary ip '%s'", c.PublicIPv4))
+				publicIPv4, _, err = client.PrimaryIP.GetByName(ctx, c.PublicIPv4)
+				if err != nil {
+					return errorHandler(state, ui, fmt.Sprintf("Could not fetch primary ip '%s'", c.PublicIPv4), err)
+				}
+				if publicIPv4 == nil {
+					return errorHandler(state, ui, "", fmt.Errorf("Could not find primary ip '%s'", c.PublicIPv4))
+				}
 			}
 		}
 		publicNetOpts := hcloud.ServerCreatePublicNet{

--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -84,7 +84,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 			return errorHandler(state, ui, "Failed to get specified Public IPv4 address", err)
 		}
 		if publicIPv4 == nil {
-		  return errorHandler(state, ui, "", fmt.Errorf("Could not find PublicIPv4"))
+			return errorHandler(state, ui, "", fmt.Errorf("Could not find PublicIPv4"))
 		}
 		publicNetOpts := hcloud.ServerCreatePublicNet{
 			EnableIPv4: true,

--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -281,12 +281,12 @@ func getPrimaryIP(ctx context.Context, client *hcloud.Client, publicIP string) (
 			return nil, fmt.Sprintf("Could not fetch primary ip with ID %d", publicIPID), err
 		}
 	} else {
-		hcloudPublicIP, _, err = client.PrimaryIP.GetByIP(ctx, publicIP)
+		hcloudPublicIP, _, err = client.PrimaryIP.GetByName(ctx, publicIP)
 		if err != nil {
 			return nil, fmt.Sprintf("Could not fetch primary ip '%s'", publicIP), err
 		}
 		if hcloudPublicIP == nil {
-			hcloudPublicIP, _, err = client.PrimaryIP.GetByName(ctx, publicIP)
+			hcloudPublicIP, _, err = client.PrimaryIP.GetByIP(ctx, publicIP)
 			if err != nil {
 				return nil, fmt.Sprintf("Could not fetch primary ip '%s'", publicIP), err
 			}

--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -81,7 +81,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 	if c.PublicIPv4 != "" {
 		publicIPv4, _, err := client.PrimaryIP.GetByIP(ctx, c.PublicIPv4)
 		if err != nil {
-			return errorHandler(state, ui, "Failed to get specified Public IPv4 address", err)
+			return errorHandler(state, ui, fmt.Sprintf("Could not fetch primary ip '%s'", c.PublicIPv4), err)
 		}
 		if publicIPv4 == nil {
 			return errorHandler(state, ui, "", fmt.Errorf("Could not find PublicIPv4"))

--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -84,7 +84,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 			return errorHandler(state, ui, fmt.Sprintf("Could not fetch primary ip '%s'", c.PublicIPv4), err)
 		}
 		if publicIPv4 == nil {
-			return errorHandler(state, ui, "", fmt.Errorf("Could not find PublicIPv4"))
+			return errorHandler(state, ui, "", fmt.Errorf("Could not find primary ip '%s'", c.PublicIPv4))
 		}
 		publicNetOpts := hcloud.ServerCreatePublicNet{
 			EnableIPv4: true,

--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -78,6 +78,19 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 		Labels:     c.ServerLabels,
 	}
 
+	if c.PublicIPv4 != "" {
+		publicIPv4, _, err := client.PrimaryIP.GetByIP(ctx, c.PublicIPv4)
+		if err != nil {
+			return errorHandler(state, ui, "Could not find PublicIPv4", err)
+		}
+		publicNetOpts := hcloud.ServerCreatePublicNet{
+			EnableIPv4: true,
+			EnableIPv6: true,
+			IPv4:       publicIPv4,
+		}
+		serverCreateOpts.PublicNet = &publicNetOpts
+	}
+
 	if c.UpgradeServerType != "" {
 		serverCreateOpts.StartAfterCreate = hcloud.Ptr(false)
 	}

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -118,7 +118,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 		},
 		{
-			Name: "happy with public ipv4",
+			Name: "happy with public ipv4 address",
 			Step: &stepCreateServer{},
 			SetupConfigFunc: func(c *Config) {
 				c.PublicIPv4 = "127.0.0.1"
@@ -154,6 +154,68 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Nil(t, payload.Networks)
 						assert.NotNil(t, payload.PublicNet)
 						assert.Equal(t, int64(1), payload.PublicNet.IPv4ID)
+					},
+					201, `{
+						"server": { "id": 8, "name": "dummy-server", "public_net": { "ipv4": { "ip": "127.0.0.1" }}},
+						"action": { "id": 3, "status": "progress" }
+					}`,
+				},
+				{"GET", "/actions/3", nil,
+					200, `{
+						"action": { "id": 3, "status": "success" }
+					}`,
+				},
+			},
+			WantStepAction: multistep.ActionContinue,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				serverID, ok := state.Get(StateServerID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), serverID)
+
+				instanceID, ok := state.Get(StateInstanceID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), instanceID)
+
+				serverIP, ok := state.Get(StateServerIP).(string)
+				assert.True(t, ok)
+				assert.Equal(t, "127.0.0.1", serverIP)
+			},
+		},
+		{
+			Name: "happy with public ipv4 ID",
+			Step: &stepCreateServer{},
+			SetupConfigFunc: func(c *Config) {
+				c.PublicIPv4 = "72"
+			},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateSSHKeyID, int64(1))
+			},
+			WantRequests: []Request{
+				{"GET", "/ssh_keys/1", nil,
+					200, `{
+						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/primary_ips/72", nil,
+					200, `{
+						"primary_ip": {
+							"id": 72,
+							"ip": "127.0.0.1",
+							"type": "ipv4"
+						}
+					}`,
+				},
+				{"POST", "/servers",
+					func(t *testing.T, r *http.Request, body []byte) {
+						payload := schema.ServerCreateRequest{}
+						assert.NoError(t, json.Unmarshal(body, &payload))
+						assert.Equal(t, "dummy-server", payload.Name)
+						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, "nbg1", payload.Location)
+						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Nil(t, payload.Networks)
+						assert.NotNil(t, payload.PublicNet)
+						assert.Equal(t, int64(72), payload.PublicNet.IPv4ID)
 					},
 					201, `{
 						"server": { "id": 8, "name": "dummy-server", "public_net": { "ipv4": { "ip": "127.0.0.1" }}},

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -464,6 +464,83 @@ func TestStepCreateServer(t *testing.T) {
 			},
 		},
 		{
+			Name: "happy with public ipv4 and ipv6 addresses",
+			Step: &stepCreateServer{},
+			SetupConfigFunc: func(c *Config) {
+				c.PublicIPv4 = "127.0.0.1"
+				c.PublicIPv6 = "::1"
+			},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateSSHKeyID, int64(1))
+			},
+			WantRequests: []Request{
+				{"GET", "/ssh_keys/1", nil,
+					200, `{
+						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/primary_ips?ip=127.0.0.1", nil,
+					200, `{
+						"primary_ips": [
+							{
+								"id": 1,
+								"ip": "127.0.0.1",
+								"type": "ipv4"
+							}
+						]
+					}`,
+				},
+				{"GET", "/primary_ips?ip=%3A%3A1", nil,
+					200, `{
+						"primary_ips": [
+							{
+								"id": 2,
+								"ip": "::1",
+								"type": "ipv6"
+							}
+						]
+					}`,
+				},
+				{"POST", "/servers",
+					func(t *testing.T, r *http.Request, body []byte) {
+						payload := schema.ServerCreateRequest{}
+						assert.NoError(t, json.Unmarshal(body, &payload))
+						assert.Equal(t, "dummy-server", payload.Name)
+						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, "nbg1", payload.Location)
+						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Nil(t, payload.Networks)
+						assert.NotNil(t, payload.PublicNet)
+						assert.Equal(t, int64(1), payload.PublicNet.IPv4ID)
+						assert.Equal(t, int64(2), payload.PublicNet.IPv6ID)
+					},
+					201, `{
+						"server": { "id": 8, "name": "dummy-server", "public_net": { "ipv4": { "ip": "127.0.0.1" }, "ipv6": { "ip": "::1" }}},
+						"action": { "id": 3, "status": "progress" }
+					}`,
+				},
+				{"GET", "/actions/3", nil,
+					200, `{
+						"action": { "id": 3, "status": "success" }
+					}`,
+				},
+			},
+			WantStepAction: multistep.ActionContinue,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				serverID, ok := state.Get(StateServerID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), serverID)
+
+				instanceID, ok := state.Get(StateInstanceID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), instanceID)
+
+				serverIP, ok := state.Get(StateServerIP).(string)
+				assert.True(t, ok)
+				assert.Equal(t, "127.0.0.1", serverIP)
+			},
+		},
+		{
 			Name: "happy with public ipv6 name",
 			Step: &stepCreateServer{},
 			SetupConfigFunc: func(c *Config) {

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -395,7 +395,7 @@ func TestStepCreateServer(t *testing.T) {
 				err, ok := state.Get(StateError).(error)
 				assert.True(t, ok)
 				assert.NotNil(t, err)
-				assert.Regexp(t, "Could not fetch primary ip with ID .*", err.Error())
+				assert.Regexp(t, "Could not fetch primary ip .*", err.Error())
 			},
 		},
 		{
@@ -759,7 +759,7 @@ func TestStepCreateServer(t *testing.T) {
 				err, ok := state.Get(StateError).(error)
 				assert.True(t, ok)
 				assert.NotNil(t, err)
-				assert.Regexp(t, "Could not fetch primary ip with ID .*", err.Error())
+				assert.Regexp(t, "Could not fetch primary ip .*", err.Error())
 			},
 		},
 	})

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -182,6 +182,74 @@ func TestStepCreateServer(t *testing.T) {
 			},
 		},
 		{
+			Name: "happy with public ipv4 name",
+			Step: &stepCreateServer{},
+			SetupConfigFunc: func(c *Config) {
+				c.PublicIPv4 = "permanent-packer-ip"
+			},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateSSHKeyID, int64(1))
+			},
+			WantRequests: []Request{
+				{"GET", "/ssh_keys/1", nil,
+					200, `{
+						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/primary_ips?ip=permanent-packer-ip", nil,
+					200, `{ "primary_ips": [] }`,
+				},
+				{"GET", "/primary_ips?name=permanent-packer-ip", nil,
+					200, `{
+						"primary_ips": [
+							{
+								"name": "permanent-packer-ip",
+								"id": 1,
+								"ip": "127.0.0.1",
+								"type": "ipv4"
+							}
+						]
+					}`,
+				},
+				{"POST", "/servers",
+					func(t *testing.T, r *http.Request, body []byte) {
+						payload := schema.ServerCreateRequest{}
+						assert.NoError(t, json.Unmarshal(body, &payload))
+						assert.Equal(t, "dummy-server", payload.Name)
+						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, "nbg1", payload.Location)
+						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Nil(t, payload.Networks)
+						assert.NotNil(t, payload.PublicNet)
+						assert.Equal(t, int64(1), payload.PublicNet.IPv4ID)
+					},
+					201, `{
+						"server": { "id": 8, "name": "dummy-server", "public_net": { "ipv4": { "ip": "127.0.0.1" }}},
+						"action": { "id": 3, "status": "progress" }
+					}`,
+				},
+				{"GET", "/actions/3", nil,
+					200, `{
+						"action": { "id": 3, "status": "success" }
+					}`,
+				},
+			},
+			WantStepAction: multistep.ActionContinue,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				serverID, ok := state.Get(StateServerID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), serverID)
+
+				instanceID, ok := state.Get(StateInstanceID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), instanceID)
+
+				serverIP, ok := state.Get(StateServerIP).(string)
+				assert.True(t, ok)
+				assert.Equal(t, "127.0.0.1", serverIP)
+			},
+		},
+		{
 			Name: "happy with public ipv4 ID",
 			Step: &stepCreateServer{},
 			SetupConfigFunc: func(c *Config) {
@@ -259,6 +327,11 @@ func TestStepCreateServer(t *testing.T) {
 					}`,
 				},
 				{"GET", "/primary_ips?ip=127.0.0.1", nil,
+					200, `{
+						"primary_ips": []
+					}`,
+				},
+				{"GET", "/primary_ips?name=127.0.0.1", nil,
 					200, `{
 						"primary_ips": []
 					}`,

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -132,6 +132,9 @@ func TestStepCreateServer(t *testing.T) {
 						"ssh_key": { "id": 1 }
 					}`,
 				},
+				{"GET", "/primary_ips?name=127.0.0.1", nil,
+					200, `{ "primary_ips": [] }`,
+				},
 				{"GET", "/primary_ips?ip=127.0.0.1", nil,
 					200, `{
 						"primary_ips": [
@@ -195,9 +198,6 @@ func TestStepCreateServer(t *testing.T) {
 					200, `{
 						"ssh_key": { "id": 1 }
 					}`,
-				},
-				{"GET", "/primary_ips?ip=permanent-packer-ip", nil,
-					200, `{ "primary_ips": [] }`,
 				},
 				{"GET", "/primary_ips?name=permanent-packer-ip", nil,
 					200, `{
@@ -326,15 +326,11 @@ func TestStepCreateServer(t *testing.T) {
 						"ssh_key": { "id": 1 }
 					}`,
 				},
-				{"GET", "/primary_ips?ip=127.0.0.1", nil,
-					200, `{
-						"primary_ips": []
-					}`,
-				},
 				{"GET", "/primary_ips?name=127.0.0.1", nil,
-					200, `{
-						"primary_ips": []
-					}`,
+					200, `{ "primary_ips": [] }`,
+				},
+				{"GET", "/primary_ips?ip=127.0.0.1", nil,
+					200, `{ "primary_ips": [] }`,
 				},
 			},
 			WantStepAction: multistep.ActionHalt,
@@ -359,6 +355,9 @@ func TestStepCreateServer(t *testing.T) {
 					200, `{
 						"ssh_key": { "id": 1 }
 					}`,
+				},
+				{"GET", "/primary_ips?name=127.0.0.1", nil,
+					200, `{ "primary_ips": [] }`,
 				},
 				{"GET", "/primary_ips?ip=127.0.0.1", nil,
 					500, `{}`,
@@ -413,6 +412,9 @@ func TestStepCreateServer(t *testing.T) {
 					200, `{
 						"ssh_key": { "id": 1 }
 					}`,
+				},
+				{"GET", "/primary_ips?name=%3A%3A1", nil,
+					200, `{ "primary_ips": [] }`,
 				},
 				{"GET", "/primary_ips?ip=%3A%3A1", nil,
 					200, `{
@@ -479,6 +481,9 @@ func TestStepCreateServer(t *testing.T) {
 						"ssh_key": { "id": 1 }
 					}`,
 				},
+				{"GET", "/primary_ips?name=127.0.0.1", nil,
+					200, `{ "primary_ips": [] }`,
+				},
 				{"GET", "/primary_ips?ip=127.0.0.1", nil,
 					200, `{
 						"primary_ips": [
@@ -489,6 +494,9 @@ func TestStepCreateServer(t *testing.T) {
 							}
 						]
 					}`,
+				},
+				{"GET", "/primary_ips?name=%3A%3A1", nil,
+					200, `{ "primary_ips": [] }`,
 				},
 				{"GET", "/primary_ips?ip=%3A%3A1", nil,
 					200, `{
@@ -554,9 +562,6 @@ func TestStepCreateServer(t *testing.T) {
 					200, `{
 						"ssh_key": { "id": 1 }
 					}`,
-				},
-				{"GET", "/primary_ips?ip=permanent-packer-ip", nil,
-					200, `{ "primary_ips": [] }`,
 				},
 				{"GET", "/primary_ips?name=permanent-packer-ip", nil,
 					200, `{
@@ -685,15 +690,11 @@ func TestStepCreateServer(t *testing.T) {
 						"ssh_key": { "id": 1 }
 					}`,
 				},
-				{"GET", "/primary_ips?ip=127.0.0.1", nil,
-					200, `{
-						"primary_ips": []
-					}`,
-				},
 				{"GET", "/primary_ips?name=127.0.0.1", nil,
-					200, `{
-						"primary_ips": []
-					}`,
+					200, `{ "primary_ips": [] }`,
+				},
+				{"GET", "/primary_ips?ip=127.0.0.1", nil,
+					200, `{ "primary_ips": [] }`,
 				},
 			},
 			WantStepAction: multistep.ActionHalt,
@@ -718,6 +719,9 @@ func TestStepCreateServer(t *testing.T) {
 					200, `{
 						"ssh_key": { "id": 1 }
 					}`,
+				},
+				{"GET", "/primary_ips?name=127.0.0.1", nil,
+					200, `{ "primary_ips": [] }`,
 				},
 				{"GET", "/primary_ips?ip=127.0.0.1", nil,
 					500, `{}`,

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -37,6 +37,7 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Equal(t, "nbg1", payload.Location)
 						assert.Equal(t, "cpx11", payload.ServerType)
 						assert.Nil(t, payload.Networks)
+						assert.Nil(t, payload.PublicNet)
 					},
 					201, `{
 						"server": { "id": 8, "name": "dummy-server", "public_net": { "ipv4": { "ip": "1.2.3.4" }}},
@@ -114,6 +115,70 @@ func TestStepCreateServer(t *testing.T) {
 				serverIP, ok := state.Get(StateServerIP).(string)
 				assert.True(t, ok)
 				assert.Equal(t, "1.2.3.4", serverIP)
+			},
+		},
+		{
+			Name: "happy with public ipv4",
+			Step: &stepCreateServer{},
+			SetupConfigFunc: func(c *Config) {
+				c.PublicIPv4 = "127.0.0.1"
+			},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateSSHKeyID, int64(1))
+			},
+			WantRequests: []Request{
+				{"GET", "/ssh_keys/1", nil,
+					200, `{
+						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/primary_ips?ip=127.0.0.1", nil,
+					200, `{
+						"primary_ips": [
+							{
+								"id": 1,
+								"ip": "127.0.0.1",
+								"type": "ipv4"
+							}
+						]
+					}`,
+				},
+				{"POST", "/servers",
+					func(t *testing.T, r *http.Request, body []byte) {
+						payload := schema.ServerCreateRequest{}
+						assert.NoError(t, json.Unmarshal(body, &payload))
+						assert.Equal(t, "dummy-server", payload.Name)
+						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, "nbg1", payload.Location)
+						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Nil(t, payload.Networks)
+						assert.NotNil(t, payload.PublicNet)
+						assert.Equal(t, int64(1), payload.PublicNet.IPv4ID)
+					},
+					201, `{
+						"server": { "id": 8, "name": "dummy-server", "public_net": { "ipv4": { "ip": "127.0.0.1" }}},
+						"action": { "id": 3, "status": "progress" }
+					}`,
+				},
+				{"GET", "/actions/3", nil,
+					200, `{
+						"action": { "id": 3, "status": "success" }
+					}`,
+				},
+			},
+			WantStepAction: multistep.ActionContinue,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				serverID, ok := state.Get(StateServerID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), serverID)
+
+				instanceID, ok := state.Get(StateInstanceID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), instanceID)
+
+				serverIP, ok := state.Get(StateServerIP).(string)
+				assert.True(t, ok)
+				assert.Equal(t, "127.0.0.1", serverIP)
 			},
 		},
 	})

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -399,5 +399,287 @@ func TestStepCreateServer(t *testing.T) {
 				assert.Regexp(t, "Could not fetch primary ip with ID .*", err.Error())
 			},
 		},
+		{
+			Name: "happy with public ipv6 address",
+			Step: &stepCreateServer{},
+			SetupConfigFunc: func(c *Config) {
+				c.PublicIPv6 = "::1"
+			},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateSSHKeyID, int64(1))
+			},
+			WantRequests: []Request{
+				{"GET", "/ssh_keys/1", nil,
+					200, `{
+						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/primary_ips?ip=%3A%3A1", nil,
+					200, `{
+						"primary_ips": [
+							{
+								"id": 1,
+								"ip": "::1",
+								"type": "ipv6"
+							}
+						]
+					}`,
+				},
+				{"POST", "/servers",
+					func(t *testing.T, r *http.Request, body []byte) {
+						payload := schema.ServerCreateRequest{}
+						assert.NoError(t, json.Unmarshal(body, &payload))
+						assert.Equal(t, "dummy-server", payload.Name)
+						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, "nbg1", payload.Location)
+						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Nil(t, payload.Networks)
+						assert.NotNil(t, payload.PublicNet)
+						assert.Equal(t, int64(1), payload.PublicNet.IPv6ID)
+					},
+					201, `{
+						"server": { "id": 8, "name": "dummy-server", "public_net": { "ipv4": { "ip": "1.2.3.4" }, "ipv6": { "ip": "::1" }}},
+						"action": { "id": 3, "status": "progress" }
+					}`,
+				},
+				{"GET", "/actions/3", nil,
+					200, `{
+						"action": { "id": 3, "status": "success" }
+					}`,
+				},
+			},
+			WantStepAction: multistep.ActionContinue,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				serverID, ok := state.Get(StateServerID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), serverID)
+
+				instanceID, ok := state.Get(StateInstanceID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), instanceID)
+
+				serverIP, ok := state.Get(StateServerIP).(string)
+				assert.True(t, ok)
+				assert.Equal(t, "1.2.3.4", serverIP)
+			},
+		},
+		{
+			Name: "happy with public ipv6 name",
+			Step: &stepCreateServer{},
+			SetupConfigFunc: func(c *Config) {
+				c.PublicIPv6 = "permanent-packer-ip"
+			},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateSSHKeyID, int64(1))
+			},
+			WantRequests: []Request{
+				{"GET", "/ssh_keys/1", nil,
+					200, `{
+						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/primary_ips?ip=permanent-packer-ip", nil,
+					200, `{ "primary_ips": [] }`,
+				},
+				{"GET", "/primary_ips?name=permanent-packer-ip", nil,
+					200, `{
+						"primary_ips": [
+							{
+								"name": "permanent-packer-ip",
+								"id": 1,
+								"ip": "::1",
+								"type": "ipv6"
+							}
+						]
+					}`,
+				},
+				{"POST", "/servers",
+					func(t *testing.T, r *http.Request, body []byte) {
+						payload := schema.ServerCreateRequest{}
+						assert.NoError(t, json.Unmarshal(body, &payload))
+						assert.Equal(t, "dummy-server", payload.Name)
+						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, "nbg1", payload.Location)
+						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Nil(t, payload.Networks)
+						assert.NotNil(t, payload.PublicNet)
+						assert.Equal(t, int64(1), payload.PublicNet.IPv6ID)
+					},
+					201, `{
+						"server": { "id": 8, "name": "dummy-server", "public_net": { "ipv4": { "ip": "1.2.3.4" }, "ipv6": { "ip": "::1" }}},
+						"action": { "id": 3, "status": "progress" }
+					}`,
+				},
+				{"GET", "/actions/3", nil,
+					200, `{
+						"action": { "id": 3, "status": "success" }
+					}`,
+				},
+			},
+			WantStepAction: multistep.ActionContinue,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				serverID, ok := state.Get(StateServerID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), serverID)
+
+				instanceID, ok := state.Get(StateInstanceID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), instanceID)
+
+				serverIP, ok := state.Get(StateServerIP).(string)
+				assert.True(t, ok)
+				assert.Equal(t, "1.2.3.4", serverIP)
+			},
+		},
+		{
+			Name: "happy with public ipv6 ID",
+			Step: &stepCreateServer{},
+			SetupConfigFunc: func(c *Config) {
+				c.PublicIPv6 = "72"
+			},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateSSHKeyID, int64(1))
+			},
+			WantRequests: []Request{
+				{"GET", "/ssh_keys/1", nil,
+					200, `{
+						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/primary_ips/72", nil,
+					200, `{
+						"primary_ip": {
+							"id": 72,
+							"ip": "::1",
+							"type": "ipv6"
+						}
+					}`,
+				},
+				{"POST", "/servers",
+					func(t *testing.T, r *http.Request, body []byte) {
+						payload := schema.ServerCreateRequest{}
+						assert.NoError(t, json.Unmarshal(body, &payload))
+						assert.Equal(t, "dummy-server", payload.Name)
+						assert.Equal(t, "debian-12", payload.Image)
+						assert.Equal(t, "nbg1", payload.Location)
+						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Nil(t, payload.Networks)
+						assert.NotNil(t, payload.PublicNet)
+						assert.Equal(t, int64(72), payload.PublicNet.IPv6ID)
+					},
+					201, `{
+						"server": { "id": 8, "name": "dummy-server", "public_net": { "ipv4": { "ip": "1.2.3.4" }, "ipv6": { "ip": "::1" }}},
+						"action": { "id": 3, "status": "progress" }
+					}`,
+				},
+				{"GET", "/actions/3", nil,
+					200, `{
+						"action": { "id": 3, "status": "success" }
+					}`,
+				},
+			},
+			WantStepAction: multistep.ActionContinue,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				serverID, ok := state.Get(StateServerID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), serverID)
+
+				instanceID, ok := state.Get(StateInstanceID).(int64)
+				assert.True(t, ok)
+				assert.Equal(t, int64(8), instanceID)
+
+				serverIP, ok := state.Get(StateServerIP).(string)
+				assert.True(t, ok)
+				assert.Equal(t, "1.2.3.4", serverIP)
+			},
+		},
+		{
+			Name: "fail to get for primary ipv4 by address",
+			Step: &stepCreateServer{},
+			SetupConfigFunc: func(c *Config) {
+				c.PublicIPv4 = "127.0.0.1"
+			},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateSSHKeyID, int64(1))
+			},
+			WantRequests: []Request{
+				{"GET", "/ssh_keys/1", nil,
+					200, `{
+						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/primary_ips?ip=127.0.0.1", nil,
+					200, `{
+						"primary_ips": []
+					}`,
+				},
+				{"GET", "/primary_ips?name=127.0.0.1", nil,
+					200, `{
+						"primary_ips": []
+					}`,
+				},
+			},
+			WantStepAction: multistep.ActionHalt,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				err, ok := state.Get(StateError).(error)
+				assert.True(t, ok)
+				assert.NotNil(t, err)
+				assert.Regexp(t, "Could not find primary ip .*", err.Error())
+			},
+		},
+		{
+			Name: "fail to search for primary ipv4 by address",
+			Step: &stepCreateServer{},
+			SetupConfigFunc: func(c *Config) {
+				c.PublicIPv4 = "127.0.0.1"
+			},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateSSHKeyID, int64(1))
+			},
+			WantRequests: []Request{
+				{"GET", "/ssh_keys/1", nil,
+					200, `{
+						"ssh_key": { "id": 1 }
+					}`,
+				},
+				{"GET", "/primary_ips?ip=127.0.0.1", nil,
+					500, `{}`,
+				},
+			},
+			WantStepAction: multistep.ActionHalt,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				err, ok := state.Get(StateError).(error)
+				assert.True(t, ok)
+				assert.NotNil(t, err)
+				assert.Regexp(t, "Could not fetch primary ip .*", err.Error())
+			},
+		},
+		{
+			Name: "fail to fetch primary ipv4 by ID",
+			Step: &stepCreateServer{},
+			SetupConfigFunc: func(c *Config) {
+				c.PublicIPv4 = "72"
+			},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateSSHKeyID, int64(1))
+			},
+			WantRequests: []Request{
+				{"GET", "/ssh_keys/1", nil,
+					200, `{
+							"ssh_key": { "id": 1 }
+						}`,
+				},
+				{"GET", "/primary_ips/72", nil,
+					404, `{}`,
+				},
+			},
+			WantStepAction: multistep.ActionHalt,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				err, ok := state.Get(StateError).(error)
+				assert.True(t, ok)
+				assert.NotNil(t, err)
+				assert.Regexp(t, "Could not fetch primary ip with ID .*", err.Error())
+			},
+		},
 	})
 }

--- a/docs/builders/hcloud.mdx
+++ b/docs/builders/hcloud.mdx
@@ -121,6 +121,9 @@ builder.
 - `networks` (array of integers) - List of Network IDs which should be
   attached to the server private network interface at creation time.
 
+- `public_ipv4` (string) - Pre-allocated Hetzner PrimaryIPv4 address
+  to use for the created server.
+
 ## Basic Example
 
 Here is a basic example. It is completely valid as soon as you enter your own

--- a/docs/builders/hcloud.mdx
+++ b/docs/builders/hcloud.mdx
@@ -121,8 +121,11 @@ builder.
 - `networks` (array of integers) - List of Network IDs which should be
   attached to the server private network interface at creation time.
 
-- `public_ipv4` (string) - ID or IP address of a pre-allocated Hetzner
-  Primary IPv4 address or to use for the created server.
+- `public_ipv4` (string) - ID, name or IP address of a pre-allocated Hetzner
+  Primary IPv4 address to use for the created server.
+
+- `public_ipv6` (string) - ID, name or IP address of a pre-allocated Hetzner
+  Primary IPv6 address to use for the created server.
 
 ## Basic Example
 

--- a/docs/builders/hcloud.mdx
+++ b/docs/builders/hcloud.mdx
@@ -121,8 +121,8 @@ builder.
 - `networks` (array of integers) - List of Network IDs which should be
   attached to the server private network interface at creation time.
 
-- `public_ipv4` (string) - Pre-allocated Hetzner PrimaryIPv4 address
-  to use for the created server.
+- `public_ipv4_address` (string) - Pre-allocated Hetzner PrimaryIPv4
+  address to use for the created server.
 
 ## Basic Example
 

--- a/docs/builders/hcloud.mdx
+++ b/docs/builders/hcloud.mdx
@@ -121,8 +121,8 @@ builder.
 - `networks` (array of integers) - List of Network IDs which should be
   attached to the server private network interface at creation time.
 
-- `public_ipv4` (string) - Pre-allocated Hetzner PrimaryIPv4 address
-  to use for the created server.
+- `public_ipv4` (string) - ID or IP address of a pre-allocated Hetzner
+  Primary IPv4 address or to use for the created server.
 
 ## Basic Example
 

--- a/docs/builders/hcloud.mdx
+++ b/docs/builders/hcloud.mdx
@@ -121,8 +121,8 @@ builder.
 - `networks` (array of integers) - List of Network IDs which should be
   attached to the server private network interface at creation time.
 
-- `public_ipv4_address` (string) - Pre-allocated Hetzner PrimaryIPv4
-  address to use for the created server.
+- `public_ipv4` (string) - Pre-allocated Hetzner PrimaryIPv4 address
+  to use for the created server.
 
 ## Basic Example
 


### PR DESCRIPTION
This PR adds the ability to specify an existing Primary IP in the Hetzner Cloud project to be used for a packer build.

For short-lived IP addresses, Hetzner sometimes sends abuse notifications to the wrong IP address user.

To avoid this, for most things I run in Hetzner Cloud, I use pre-allocated Primary IPs, set to not auto-delete when the server is removed, so that I have easier tracking of IP address allocation to respond appropriately to Hetzner abuse notifications.
