### PR TITLE
fix: do not pass nil error to error handler

### DIFF
--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -161,8 +161,7 @@ func (s *stepCreateServer) Cleanup(state multistep.StateBag) {
 	ui.Say("Destroying server...")
 	_, _, err := client.Server.DeleteWithResult(context.TODO(), &hcloud.Server{ID: s.serverId})
 	if err != nil {
-		ui.Error(fmt.Sprintf(
-			"Error destroying server. Please destroy it manually: %s", err))
+		errorHandler(state, ui, "Could not destroy server (please destroy it manually)", err)
 	}
 }
 

--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -44,7 +44,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 			return errorHandler(state, ui, fmt.Sprintf("Could not fetch SSH key '%s'", k), err)
 		}
 		if sshKey == nil {
-			return errorHandler(state, ui, fmt.Sprintf("Could not find SSH key '%s'", k), err)
+			return errorHandler(state, ui, "", fmt.Errorf("Could not find SSH key '%s'", k))
 		}
 		sshKeys = append(sshKeys, sshKey)
 	}

--- a/builder/hcloud/step_pre_validate.go
+++ b/builder/hcloud/step_pre_validate.go
@@ -28,7 +28,7 @@ func (s *stepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 		return errorHandler(state, ui, fmt.Sprintf("Could not fetch server type '%s'", c.ServerType), err)
 	}
 	if serverType == nil {
-		return errorHandler(state, ui, fmt.Sprintf("Could not find server type '%s'", c.ServerType), err)
+		return errorHandler(state, ui, "", fmt.Errorf("Could not find server type '%s'", c.ServerType))
 	}
 	state.Put(StateServerType, serverType)
 
@@ -39,7 +39,7 @@ func (s *stepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 			return errorHandler(state, ui, fmt.Sprintf("Could not fetch upgrade server type '%s'", c.UpgradeServerType), err)
 		}
 		if serverType == nil {
-			return errorHandler(state, ui, fmt.Sprintf("Could not find upgrade server type '%s'", c.UpgradeServerType), err)
+			return errorHandler(state, ui, "", fmt.Errorf("Could not find upgrade server type '%s'", c.UpgradeServerType))
 		}
 
 		if serverType.Architecture != upgradeServerType.Architecture {


### PR DESCRIPTION
During the previous error handling refactor, we missed some parts where no error was generated, but still use it. 