### PR TITLE
fix: use first host ip in public ipv6 network

### DIFF
--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -463,3 +463,57 @@ func TestStepCreateServer(t *testing.T) {
 		},
 	})
 }
+
+func TestFirstAvailableIP(t *testing.T) {
+	testCases := []struct {
+		name   string
+		server *hcloud.Server
+		want   string
+	}{
+		{
+			name:   "empty",
+			server: &hcloud.Server{},
+			want:   "",
+		},
+		{
+			name: "public_ipv4",
+			server: &hcloud.Server{
+				PublicNet: hcloud.ServerPublicNetFromSchema(schema.ServerPublicNet{
+					IPv4: schema.ServerPublicNetIPv4{ID: 1, IP: "1.2.3.4"},
+					IPv6: schema.ServerPublicNetIPv6{ID: 2, IP: "2a01:4f8:1c19:1403::/64"},
+				}),
+				PrivateNet: []hcloud.ServerPrivateNet{
+					hcloud.ServerPrivateNetFromSchema(schema.ServerPrivateNet{Network: 3, IP: "10.0.0.1"}),
+				},
+			},
+			want: "1.2.3.4",
+		},
+		{
+			name: "public_ipv6",
+			server: &hcloud.Server{
+				PublicNet: hcloud.ServerPublicNetFromSchema(schema.ServerPublicNet{
+					IPv6: schema.ServerPublicNetIPv6{ID: 2, IP: "2a01:4f8:1c19:1403::/64"},
+				}),
+				PrivateNet: []hcloud.ServerPrivateNet{
+					hcloud.ServerPrivateNetFromSchema(schema.ServerPrivateNet{Network: 3, IP: "10.0.0.1"}),
+				},
+			},
+			want: "2a01:4f8:1c19:1403::1",
+		},
+		{
+			name: "private_ipv4",
+			server: &hcloud.Server{
+				PrivateNet: []hcloud.ServerPrivateNet{
+					hcloud.ServerPrivateNetFromSchema(schema.ServerPrivateNet{Network: 3, IP: "10.0.0.1"}),
+				},
+			},
+			want: "10.0.0.1",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := firstAvailableIP(testCase.server)
+			assert.Equal(t, testCase.want, result)
+		})
+	}
+}


### PR DESCRIPTION
Since the public net ipv6 is a network (CIDR block), we must use the next host IP in that network.

  