### PR TITLE
chore: replace deprecated server type with cx22

### DIFF
--- a/.web-docs/components/builder/hcloud/README.md
+++ b/.web-docs/components/builder/hcloud/README.md
@@ -157,7 +157,7 @@ source "hcloud" "basic_example" {
   token = "YOUR API TOKEN"
   image = "ubuntu-22.04"
   location = "nbg1"
-  server_type = "cx11"
+  server_type = "cx22"
   ssh_username = "root"
 }
 

--- a/builder/hcloud/builder_acc_test.go
+++ b/builder/hcloud/builder_acc_test.go
@@ -49,7 +49,7 @@ const testBuilderAccBasic = `
 	"builders": [{
 		"type": "hcloud",
 		"location": "nbg1",
-		"server_type": "cx11",
+		"server_type": "cx22",
 		"image": "ubuntu-22.04",
 		"user_data": "",
 		"user_data_file": "",

--- a/docs/builders/hcloud.mdx
+++ b/docs/builders/hcloud.mdx
@@ -147,7 +147,7 @@ source "hcloud" "basic_example" {
   token = "YOUR API TOKEN"
   image = "ubuntu-22.04"
   location = "nbg1"
-  server_type = "cx11"
+  server_type = "cx22"
   ssh_username = "root"
 }
 


### PR DESCRIPTION
Learn more: https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated