### PR TITLE
chore: replace deprecated server type with cx22

### DIFF
--- a/builder/hcloud/artifact_test.go
+++ b/builder/hcloud/artifact_test.go
@@ -70,7 +70,7 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 		StateData: map[string]interface{}{
 			"source_image":    "ubuntu-24.04",
 			"source_image_id": int64(161547269),
-			"server_type":     "cpx11",
+			"server_type":     "cx22",
 		},
 	}
 
@@ -88,7 +88,7 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 		SourceImageID: "161547269",
 		Labels: map[string]string{
 			"source_image": "ubuntu-24.04",
-			"server_type":  "cpx11",
+			"server_type":  "cx22",
 		},
 	}, image)
 }

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -22,7 +22,7 @@ func TestStepCreateServer(t *testing.T) {
 			Step: &stepCreateServer{},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
@@ -42,7 +42,7 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Equal(t, "dummy-server", payload.Name)
 						assert.Equal(t, int64(114690387), int64(payload.Image.(float64)))
 						assert.Equal(t, "nbg1", payload.Location)
-						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Equal(t, "cx22", payload.ServerType)
 						assert.True(t, payload.PublicNet.EnableIPv4)
 						assert.True(t, payload.PublicNet.EnableIPv6)
 						assert.Nil(t, payload.Networks)
@@ -84,7 +84,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
@@ -104,7 +104,7 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Equal(t, "dummy-server", payload.Name)
 						assert.Equal(t, int64(114690387), int64(payload.Image.(float64)))
 						assert.Equal(t, "nbg1", payload.Location)
-						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Equal(t, "cx22", payload.ServerType)
 						assert.Equal(t, []int64{12}, payload.Networks)
 					},
 					201, `{
@@ -146,7 +146,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
@@ -190,7 +190,7 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Equal(t, "dummy-server", payload.Name)
 						assert.Equal(t, int64(114690387), int64(payload.Image.(float64)))
 						assert.Equal(t, "nbg1", payload.Location)
-						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Equal(t, "cx22", payload.ServerType)
 						assert.Nil(t, payload.Networks)
 						assert.NotNil(t, payload.PublicNet)
 						assert.Equal(t, int64(1), payload.PublicNet.IPv4ID)
@@ -234,7 +234,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
@@ -282,7 +282,7 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Equal(t, "dummy-server", payload.Name)
 						assert.Equal(t, int64(114690387), int64(payload.Image.(float64)))
 						assert.Equal(t, "nbg1", payload.Location)
-						assert.Equal(t, "cpx11", payload.ServerType)
+						assert.Equal(t, "cx22", payload.ServerType)
 						assert.Nil(t, payload.Networks)
 						assert.NotNil(t, payload.PublicNet)
 						assert.Equal(t, int64(1), payload.PublicNet.IPv4ID)
@@ -325,7 +325,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
@@ -361,7 +361,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
@@ -397,7 +397,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,
@@ -433,7 +433,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"})
 			},
 			WantRequests: []Request{
 				{"GET", "/ssh_keys/1", nil,

--- a/builder/hcloud/step_pre_validate_test.go
+++ b/builder/hcloud/step_pre_validate_test.go
@@ -21,17 +21,17 @@ func TestStepPreValidate(t *testing.T) {
 				Force:        false,
 			},
 			SetupConfigFunc: func(c *Config) {
-				c.UpgradeServerType = "cpx21"
+				c.UpgradeServerType = "cx22"
 			},
 			WantRequests: []Request{
-				{"GET", "/server_types?name=cpx11", nil,
+				{"GET", "/server_types?name=cx22", nil,
 					200, `{
-						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
+						"server_types": [{ "id": 9, "name": "cx22", "architecture": "x86"}]
 					}`,
 				},
-				{"GET", "/server_types?name=cpx21", nil,
+				{"GET", "/server_types?name=cx22", nil,
 					200, `{
-						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
+						"server_types": [{ "id": 10, "name": "cx22", "architecture": "x86"}]
 					}`,
 				},
 				{"GET", "/images?architecture=x86&page=1&type=snapshot", nil,
@@ -44,7 +44,7 @@ func TestStepPreValidate(t *testing.T) {
 			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
 				serverType, ok := state.Get(StateServerType).(*hcloud.ServerType)
 				assert.True(t, ok)
-				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"}, *serverType)
+				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"}, *serverType)
 
 				_, ok = state.Get(StateSnapshotIDOld).(int64)
 				assert.False(t, ok)
@@ -57,17 +57,17 @@ func TestStepPreValidate(t *testing.T) {
 				Force:        false,
 			},
 			SetupConfigFunc: func(c *Config) {
-				c.UpgradeServerType = "cpx21"
+				c.UpgradeServerType = "cx22"
 			},
 			WantRequests: []Request{
-				{"GET", "/server_types?name=cpx11", nil,
+				{"GET", "/server_types?name=cx22", nil,
 					200, `{
-						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
+						"server_types": [{ "id": 9, "name": "cx22", "architecture": "x86"}]
 					}`,
 				},
-				{"GET", "/server_types?name=cpx21", nil,
+				{"GET", "/server_types?name=cx22", nil,
 					200, `{
-						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
+						"server_types": [{ "id": 10, "name": "cx22", "architecture": "x86"}]
 					}`,
 				},
 				{"GET", "/images?architecture=x86&page=1&type=snapshot", nil,
@@ -80,7 +80,7 @@ func TestStepPreValidate(t *testing.T) {
 			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
 				serverType, ok := state.Get(StateServerType).(*hcloud.ServerType)
 				assert.True(t, ok)
-				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"}, *serverType)
+				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"}, *serverType)
 
 				_, ok = state.Get(StateSnapshotIDOld).(int64)
 				assert.False(t, ok)
@@ -98,17 +98,17 @@ func TestStepPreValidate(t *testing.T) {
 				Force:        true,
 			},
 			SetupConfigFunc: func(c *Config) {
-				c.UpgradeServerType = "cpx21"
+				c.UpgradeServerType = "cx22"
 			},
 			WantRequests: []Request{
-				{"GET", "/server_types?name=cpx11", nil,
+				{"GET", "/server_types?name=cx22", nil,
 					200, `{
-						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
+						"server_types": [{ "id": 9, "name": "cx22", "architecture": "x86"}]
 					}`,
 				},
-				{"GET", "/server_types?name=cpx21", nil,
+				{"GET", "/server_types?name=cx22", nil,
 					200, `{
-						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
+						"server_types": [{ "id": 10, "name": "cx22", "architecture": "x86"}]
 					}`,
 				},
 				{"GET", "/images?architecture=x86&page=1&type=snapshot", nil,
@@ -121,7 +121,7 @@ func TestStepPreValidate(t *testing.T) {
 			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
 				serverType, ok := state.Get(StateServerType).(*hcloud.ServerType)
 				assert.True(t, ok)
-				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"}, *serverType)
+				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cx22", Architecture: "x86"}, *serverType)
 
 				snapshotIDOld, ok := state.Get(StateSnapshotIDOld).(int64)
 				assert.True(t, ok)

--- a/builder/hcloud/step_test.go
+++ b/builder/hcloud/step_test.go
@@ -45,7 +45,7 @@ func RunStepTestCases(t *testing.T, testCases []StepTestCase) {
 				ServerName:   "dummy-server",
 				Image:        "debian-12",
 				SnapshotName: "dummy-snapshot",
-				ServerType:   "cpx11",
+				ServerType:   "cx22",
 				Location:     "nbg1",
 				SSHKeys:      []string{"1"},
 			}

--- a/example/build.pkr.hcl
+++ b/example/build.pkr.hcl
@@ -21,7 +21,7 @@ source "hcloud" "example" {
 
   location    = "hel1"
   image       = "ubuntu-24.04"
-  server_type = "cpx11"
+  server_type = "cx22"
   server_name = "hcloud-example"
 
   ssh_username = "root"

--- a/example/build_hcp.pkr.hcl
+++ b/example/build_hcp.pkr.hcl
@@ -21,7 +21,7 @@ source "hcloud" "example" {
 
   location    = "hel1"
   image       = "ubuntu-24.04"
-  server_type = "cpx11"
+  server_type = "cx22"
   server_name = "hcloud-example"
 
   ssh_username = "root"


### PR DESCRIPTION
Learn more: https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated