### PR TITLE
fix: wait server firewall actions to settle

### DIFF
--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -63,6 +63,13 @@ func TestStepCreateServer(t *testing.T) {
 						"meta": { "pagination": { "page": 1 }}
 					}`,
 				},
+				{Method: "GET", Path: "/firewalls/actions?page=1&status=running",
+					Status: 200,
+					JSONRaw: `{
+						"actions": [],
+						"meta": { "pagination": { "page": 1 }}
+					}`,
+				},
 			},
 			WantStepAction: multistep.ActionContinue,
 			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
@@ -123,6 +130,13 @@ func TestStepCreateServer(t *testing.T) {
 						"actions": [
 							{ "id": 3, "status": "success" }
 						],
+						"meta": { "pagination": { "page": 1 }}
+					}`,
+				},
+				{Method: "GET", Path: "/firewalls/actions?page=1&status=running",
+					Status: 200,
+					JSONRaw: `{
+						"actions": [],
 						"meta": { "pagination": { "page": 1 }}
 					}`,
 				},
@@ -217,6 +231,13 @@ func TestStepCreateServer(t *testing.T) {
 						"actions": [
 							{ "id": 3, "status": "success" }
 						],
+						"meta": { "pagination": { "page": 1 }}
+					}`,
+				},
+				{Method: "GET", Path: "/firewalls/actions?page=1&status=running",
+					Status: 200,
+					JSONRaw: `{
+						"actions": [],
 						"meta": { "pagination": { "page": 1 }}
 					}`,
 				},
@@ -316,6 +337,13 @@ func TestStepCreateServer(t *testing.T) {
 						"actions": [
 							{ "id": 3, "status": "success" }
 						],
+						"meta": { "pagination": { "page": 1 }}
+					}`,
+				},
+				{Method: "GET", Path: "/firewalls/actions?page=1&status=running",
+					Status: 200,
+					JSONRaw: `{
+						"actions": [],
 						"meta": { "pagination": { "page": 1 }}
 					}`,
 				},


### PR DESCRIPTION
Closes #205

Prevents a server `locked` error from the API, when trying to change the type of the server, while `firewall_apply` are still running in the backend.

The `firewall_apply` actions are triggered by label selectors.

