### PR TITLE
ci: build and test with Go 1.23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches: [main]
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  GOTOOLCHAIN: local
+
 permissions:
   contents: read
 
@@ -15,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - uses: golangci/golangci-lint-action@v6
         with:
@@ -27,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - run: go mod tidy
 
@@ -42,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - run: make generate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
   push:
     tags: [v*]
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -20,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  GOTOOLCHAIN: local
+
 permissions:
   contents: read
 
@@ -24,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - run: make test
 
@@ -49,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.23"
 
       - uses: hetznercloud/tps-action@main
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hetznercloud/packer-plugin-hcloud
 
 go 1.21.0
 
-toolchain go1.22.7
+toolchain go1.23.1
 
 require (
 	github.com/hashicorp/hcl/v2 v2.22.0


### PR DESCRIPTION
This PR updates the Go version used in our CI to Go 1.23. See https://github.com/hetznercloud/cli/pull/871 for a previous discussion.