### PR TITLE
ci: use github token when downloading packer deps from github

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,7 @@ jobs:
 
     env:
       PACKER_LOG: "1"
+      PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes broken CI jobs that fails to download deps on packer init:

https://github.com/hetznercloud/packer-plugin-hcloud/actions/runs/11889406656/job/33125902020#step:5:26