### PR TITLE
docs: fix typo in field name

### DIFF
--- a/.web-docs/components/builder/hcloud/README.md
+++ b/.web-docs/components/builder/hcloud/README.md
@@ -148,7 +148,7 @@ builder.
 - `public_ipv6` (string) - ID, name or IP address of a pre-allocated Hetzner
   Primary IPv6 address to use for the created server.
 
-- `public_ipv4_disabled` (bool) - Disable the public ipv6 for the created server.
+- `public_ipv6_disabled` (bool) - Disable the public ipv6 for the created server.
 
 - `firewalls` (array of strings) - List of Firewall by name or id to be attached
   to the created server.

--- a/docs/builders/hcloud.mdx
+++ b/docs/builders/hcloud.mdx
@@ -138,7 +138,7 @@ builder.
 - `public_ipv6` (string) - ID, name or IP address of a pre-allocated Hetzner
   Primary IPv6 address to use for the created server.
 
-- `public_ipv4_disabled` (bool) - Disable the public ipv6 for the created server.
+- `public_ipv6_disabled` (bool) - Disable the public ipv6 for the created server.
 
 - `firewalls` (array of strings) - List of Firewall by name or id to be attached
   to the created server.


### PR DESCRIPTION
This was reported in our Forum: https://forum.hetzner.com/index.php?thread/31853-fehler-in-der-doku-f%C3%BCr-plugin-packer-hetzner-cloud/