### PR TITLE
docs: speed up disk trimming using fstrim

### DIFF
--- a/.web-docs/components/builder/hcloud/README.md
+++ b/.web-docs/components/builder/hcloud/README.md
@@ -223,9 +223,8 @@ Below are a few commands that might useful:
 Once the cleanup is complete, you must discard the now unused blocks from the disk. This can be done with the following:
 
 ```bash
-dd if=/dev/zero of=/zero bs=4M || true
+fstrim --all || true
 sync
-rm -f /zero
 ```
 
 To speed up the process above, you may configure cloud-init to not grow the system partition to the server disk size during the boot process, leaving you with a 4GB system partition:

--- a/docs/builders/hcloud.mdx
+++ b/docs/builders/hcloud.mdx
@@ -213,9 +213,8 @@ Below are a few commands that might useful:
 Once the cleanup is complete, you must discard the now unused blocks from the disk. This can be done with the following:
 
 ```bash
-dd if=/dev/zero of=/zero bs=4M || true
+fstrim --all || true
 sync
-rm -f /zero
 ```
 
 To speed up the process above, you may configure cloud-init to not grow the system partition to the server disk size during the boot process, leaving you with a 4GB system partition:

--- a/example/docker/cleanup.sh
+++ b/example/docker/cleanup.sh
@@ -42,9 +42,8 @@ clean_root() {
 }
 
 flush_disk() {
-  dd if=/dev/zero of=/zero bs=4M || true
+  fstrim --all || true
   sync
-  rm -f /zero
 }
 
 clean_cloud_init


### PR DESCRIPTION
Small optimization, to speed up the cleanup script.

fstrim is way faster than zeroing the free space on the disk.