### PR TITLE
feat: add `skip_create_snapshot` config to the builder

### DIFF
--- a/.web-docs/components/builder/hcloud/README.md
+++ b/.web-docs/components/builder/hcloud/README.md
@@ -79,6 +79,8 @@ builder.
 - `server_labels` (map of key/value strings) - Key/value pair labels to
   apply to the created server.
 
+- `skip_create_snapshot` (boolean) - Skips snapshot creation.
+
 - `snapshot_name` (string) - The name of the resulting snapshot that will
   appear in your account as image description. Defaults to `packer-{{timestamp}}` (see
   [configuration templates](/packer/docs/templates/legacy_json_templates/engine) for more info).

--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -40,12 +40,13 @@ type Config struct {
 	Image             string            `mapstructure:"image"`
 	ImageFilter       *imageFilter      `mapstructure:"image_filter"`
 
-	SnapshotName   string            `mapstructure:"snapshot_name"`
-	SnapshotLabels map[string]string `mapstructure:"snapshot_labels"`
-	UserData       string            `mapstructure:"user_data"`
-	UserDataFile   string            `mapstructure:"user_data_file"`
-	SSHKeys        []string          `mapstructure:"ssh_keys"`
-	SSHKeysLabels  map[string]string `mapstructure:"ssh_keys_labels"`
+	SkipCreateSnapshot bool              `mapstructure:"skip_create_snapshot"`
+	SnapshotName       string            `mapstructure:"snapshot_name"`
+	SnapshotLabels     map[string]string `mapstructure:"snapshot_labels"`
+	UserData           string            `mapstructure:"user_data"`
+	UserDataFile       string            `mapstructure:"user_data_file"`
+	SSHKeys            []string          `mapstructure:"ssh_keys"`
+	SSHKeysLabels      map[string]string `mapstructure:"ssh_keys_labels"`
 
 	Networks           []int64  `mapstructure:"networks"`
 	PublicIPv4         string   `mapstructure:"public_ipv4"`

--- a/builder/hcloud/config.hcl2spec.go
+++ b/builder/hcloud/config.hcl2spec.go
@@ -77,6 +77,7 @@ type FlatConfig struct {
 	UpgradeServerType         *string           `mapstructure:"upgrade_server_type" cty:"upgrade_server_type" hcl:"upgrade_server_type"`
 	Image                     *string           `mapstructure:"image" cty:"image" hcl:"image"`
 	ImageFilter               *FlatimageFilter  `mapstructure:"image_filter" cty:"image_filter" hcl:"image_filter"`
+	SkipCreateSnapshot        *bool             `mapstructure:"skip_create_snapshot" cty:"skip_create_snapshot" hcl:"skip_create_snapshot"`
 	SnapshotName              *string           `mapstructure:"snapshot_name" cty:"snapshot_name" hcl:"snapshot_name"`
 	SnapshotLabels            map[string]string `mapstructure:"snapshot_labels" cty:"snapshot_labels" hcl:"snapshot_labels"`
 	UserData                  *string           `mapstructure:"user_data" cty:"user_data" hcl:"user_data"`
@@ -171,6 +172,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"upgrade_server_type":          &hcldec.AttrSpec{Name: "upgrade_server_type", Type: cty.String, Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
 		"image_filter":                 &hcldec.BlockSpec{TypeName: "image_filter", Nested: hcldec.ObjectSpec((*FlatimageFilter)(nil).HCL2Spec())},
+		"skip_create_snapshot":         &hcldec.AttrSpec{Name: "skip_create_snapshot", Type: cty.Bool, Required: false},
 		"snapshot_name":                &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 		"snapshot_labels":              &hcldec.AttrSpec{Name: "snapshot_labels", Type: cty.Map(cty.String), Required: false},
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},

--- a/builder/hcloud/step_create_snapshot.go
+++ b/builder/hcloud/step_create_snapshot.go
@@ -20,6 +20,12 @@ func (s *stepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) 
 
 	serverID := state.Get(StateServerID).(int64)
 
+	// Skip snapshot creation if skip_create_snapshot is set to true.
+	if c.SkipCreateSnapshot {
+		ui.Say("Skipping snapshot creation...")
+		return multistep.ActionContinue
+	}
+
 	ui.Say("Creating snapshot...")
 	ui.Say("This can take some time")
 	result, _, err := client.Server.CreateImage(ctx, &hcloud.Server{ID: serverID}, &hcloud.ServerCreateImageOpts{

--- a/builder/hcloud/step_create_snapshot_test.go
+++ b/builder/hcloud/step_create_snapshot_test.go
@@ -23,7 +23,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 				state.Put(StateServerID, int64(8))
 			},
 			WantRequests: []mockutil.Request{
-				{Method: "POST", Path: "/servers/8/actions/create_image",
+				{
+					Method: "POST", Path: "/servers/8/actions/create_image",
 					Want: func(t *testing.T, req *http.Request) {
 						payload := decodeJSONBody(t, req.Body, &schema.ServerActionCreateImageRequest{})
 						assert.Equal(t, "dummy-snapshot", *payload.Description)
@@ -35,7 +36,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 						"action": { "id": 3, "status": "running" }
 					}`,
 				},
-				{Method: "GET", Path: "/actions?id=3&page=1&sort=status&sort=id",
+				{
+					Method: "GET", Path: "/actions?id=3&page=1&sort=status&sort=id",
 					Status: 200,
 					JSONRaw: `{
 						"actions": [
@@ -63,7 +65,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 				state.Put(StateServerID, int64(8))
 			},
 			WantRequests: []mockutil.Request{
-				{Method: "POST", Path: "/servers/8/actions/create_image",
+				{
+					Method: "POST", Path: "/servers/8/actions/create_image",
 					Want: func(t *testing.T, req *http.Request) {
 						payload := decodeJSONBody(t, req.Body, &schema.ServerActionCreateImageRequest{})
 						assert.Equal(t, "dummy-snapshot", *payload.Description)
@@ -87,7 +90,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 				state.Put(StateServerID, int64(8))
 			},
 			WantRequests: []mockutil.Request{
-				{Method: "POST", Path: "/servers/8/actions/create_image",
+				{
+					Method: "POST", Path: "/servers/8/actions/create_image",
 					Want: func(t *testing.T, req *http.Request) {
 						payload := decodeJSONBody(t, req.Body, &schema.ServerActionCreateImageRequest{})
 						assert.Equal(t, "dummy-snapshot", *payload.Description)
@@ -99,7 +103,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 						"action": { "id": 3, "status": "running" }
 					}`,
 				},
-				{Method: "GET", Path: "/actions?id=3&page=1&sort=status&sort=id",
+				{
+					Method: "GET", Path: "/actions?id=3&page=1&sort=status&sort=id",
 					Status: 200,
 					JSONRaw: `{
 						"actions": [
@@ -132,7 +137,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 				state.Put(StateSnapshotIDOld, int64(20))
 			},
 			WantRequests: []mockutil.Request{
-				{Method: "POST", Path: "/servers/8/actions/create_image",
+				{
+					Method: "POST", Path: "/servers/8/actions/create_image",
 					Want: func(t *testing.T, req *http.Request) {
 						payload := decodeJSONBody(t, req.Body, &schema.ServerActionCreateImageRequest{})
 						assert.Equal(t, "dummy-snapshot", *payload.Description)
@@ -144,7 +150,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 						"action": { "id": 3, "status": "running" }
 					}`,
 				},
-				{Method: "GET", Path: "/actions?id=3&page=1&sort=status&sort=id",
+				{
+					Method: "GET", Path: "/actions?id=3&page=1&sort=status&sort=id",
 					Status: 200,
 					JSONRaw: `{
 						"actions": [
@@ -153,7 +160,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 						"meta": { "pagination": { "page": 1 }}
 					}`,
 				},
-				{Method: "DELETE", Path: "/images/20",
+				{
+					Method: "DELETE", Path: "/images/20",
 					Status: 204,
 				},
 			},
@@ -176,7 +184,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 				state.Put(StateSnapshotIDOld, int64(20))
 			},
 			WantRequests: []mockutil.Request{
-				{Method: "POST", Path: "/servers/8/actions/create_image",
+				{
+					Method: "POST", Path: "/servers/8/actions/create_image",
 					Want: func(t *testing.T, req *http.Request) {
 						payload := decodeJSONBody(t, req.Body, &schema.ServerActionCreateImageRequest{})
 						assert.Equal(t, "dummy-snapshot", *payload.Description)
@@ -188,7 +197,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 						"action": { "id": 3, "status": "running" }
 					}`,
 				},
-				{Method: "GET", Path: "/actions?id=3&page=1&sort=status&sort=id",
+				{
+					Method: "GET", Path: "/actions?id=3&page=1&sort=status&sort=id",
 					Status: 200,
 					JSONRaw: `{
 						"actions": [
@@ -197,7 +207,8 @@ func TestStepCreateSnapshot(t *testing.T) {
 						"meta": { "pagination": { "page": 1 }}
 					}`,
 				},
-				{Method: "DELETE", Path: "/images/20",
+				{
+					Method: "DELETE", Path: "/images/20",
 					Status: 400,
 				},
 			},
@@ -208,6 +219,15 @@ func TestStepCreateSnapshot(t *testing.T) {
 				assert.NotNil(t, err)
 				assert.Regexp(t, "Could not delete old snapshot id=20: .*", err.Error())
 			},
+		},
+		{
+			Name: "skip snapshot creation",
+			Step: &stepCreateSnapshot{},
+			SetupStateFunc: func(state multistep.StateBag) {
+				state.Put(StateServerID, int64(8))
+				state.Put(StateConfig, &Config{SkipCreateSnapshot: true})
+			},
+			WantStepAction: multistep.ActionContinue,
 		},
 	})
 }

--- a/builder/hcloud/step_pre_validate.go
+++ b/builder/hcloud/step_pre_validate.go
@@ -50,6 +50,11 @@ func (s *stepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 		}
 	}
 
+	// Skip snapshot name validation if skip_create_snapshot is set to true.
+	if c.SkipCreateSnapshot {
+		return multistep.ActionContinue
+	}
+
 	ui.Say(fmt.Sprintf("Validating snapshot name: %s", s.SnapshotName))
 
 	// We would like to ask only for snapshots with a certain name using

--- a/builder/hcloud/step_pre_validate_test.go
+++ b/builder/hcloud/step_pre_validate_test.go
@@ -25,19 +25,22 @@ func TestStepPreValidate(t *testing.T) {
 				c.UpgradeServerType = "cpx21"
 			},
 			WantRequests: []mockutil.Request{
-				{Method: "GET", Path: "/server_types?name=cpx11",
+				{
+					Method: "GET", Path: "/server_types?name=cpx11",
 					Status: 200,
 					JSONRaw: `{
 						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
 					}`,
 				},
-				{Method: "GET", Path: "/server_types?name=cpx21",
+				{
+					Method: "GET", Path: "/server_types?name=cpx21",
 					Status: 200,
 					JSONRaw: `{
 						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
 					}`,
 				},
-				{Method: "GET", Path: "/images?architecture=x86&page=1&type=snapshot",
+				{
+					Method: "GET", Path: "/images?architecture=x86&page=1&type=snapshot",
 					Status: 200,
 					JSONRaw: `{
 						"images": []
@@ -64,19 +67,22 @@ func TestStepPreValidate(t *testing.T) {
 				c.UpgradeServerType = "cpx21"
 			},
 			WantRequests: []mockutil.Request{
-				{Method: "GET", Path: "/server_types?name=cpx11",
+				{
+					Method: "GET", Path: "/server_types?name=cpx11",
 					Status: 200,
 					JSONRaw: `{
 						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
 					}`,
 				},
-				{Method: "GET", Path: "/server_types?name=cpx21",
+				{
+					Method: "GET", Path: "/server_types?name=cpx21",
 					Status: 200,
 					JSONRaw: `{
 						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
 					}`,
 				},
-				{Method: "GET", Path: "/images?architecture=x86&page=1&type=snapshot",
+				{
+					Method: "GET", Path: "/images?architecture=x86&page=1&type=snapshot",
 					Status: 200,
 					JSONRaw: `{
 						"images": [{ "id": 1, "description": "dummy-snapshot"}]
@@ -108,19 +114,22 @@ func TestStepPreValidate(t *testing.T) {
 				c.UpgradeServerType = "cpx21"
 			},
 			WantRequests: []mockutil.Request{
-				{Method: "GET", Path: "/server_types?name=cpx11",
+				{
+					Method: "GET", Path: "/server_types?name=cpx11",
 					Status: 200,
 					JSONRaw: `{
 						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
 					}`,
 				},
-				{Method: "GET", Path: "/server_types?name=cpx21",
+				{
+					Method: "GET", Path: "/server_types?name=cpx21",
 					Status: 200,
 					JSONRaw: `{
 						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
 					}`,
 				},
-				{Method: "GET", Path: "/images?architecture=x86&page=1&type=snapshot",
+				{
+					Method: "GET", Path: "/images?architecture=x86&page=1&type=snapshot",
 					Status: 200,
 					JSONRaw: `{
 						"images": [{ "id": 1, "description": "dummy-snapshot"}]
@@ -136,6 +145,38 @@ func TestStepPreValidate(t *testing.T) {
 				snapshotIDOld, ok := state.Get(StateSnapshotIDOld).(int64)
 				assert.True(t, ok)
 				assert.Equal(t, int64(1), snapshotIDOld)
+			},
+		},
+		{
+			Name: "skip snapshot name validation",
+			Step: &stepPreValidate{
+				SnapshotName: "dummy-snapshot",
+			},
+			SetupConfigFunc: func(c *Config) {
+				c.UpgradeServerType = "cpx21"
+				c.SkipCreateSnapshot = true
+			},
+			WantRequests: []mockutil.Request{
+				{
+					Method: "GET", Path: "/server_types?name=cpx11",
+					Status: 200,
+					JSONRaw: `{
+						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
+					}`,
+				},
+				{
+					Method: "GET", Path: "/server_types?name=cpx21",
+					Status: 200,
+					JSONRaw: `{
+						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
+					}`,
+				},
+			},
+			WantStepAction: multistep.ActionContinue,
+			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
+				serverType, ok := state.Get(StateServerType).(*hcloud.ServerType)
+				assert.True(t, ok)
+				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"}, *serverType)
 			},
 		},
 	})

--- a/docs/builders/hcloud.mdx
+++ b/docs/builders/hcloud.mdx
@@ -92,6 +92,8 @@ builder.
 - `server_labels` (map of key/value strings) - Key/value pair labels to
   apply to the created server.
 
+- `skip_create_snapshot` (boolean) - Skips snapshot creation.
+
 - `snapshot_name` (string) - The name of the resulting snapshot that will
   appear in your account as image description. Defaults to `packer-{{timestamp}}` (see
   [configuration templates](/packer/docs/templates/legacy_json_templates/engine) for more info).


### PR DESCRIPTION
If skip_create_snapshot is set to true, we don't create the snapshot but only run the defined provisioners to ensure all scripts are correct. When set to false, the snapshot is created.

Closes #86 
