### PR TITLE
ci: increase golangci-lint timeout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8 # renovate: datasource=github-releases depName=golangci/golangci-lint
+          args: --timeout 5m
 
   check-mod-tidy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ensure the lint job does not fail with timeout.