### PR TITLE
docs: update deprecated server types

### DIFF
--- a/.web-docs/components/builder/hcloud/README.md
+++ b/.web-docs/components/builder/hcloud/README.md
@@ -163,9 +163,9 @@ access tokens:
 ```hcl
 source "hcloud" "basic_example" {
   token = "YOUR API TOKEN"
-  image = "ubuntu-22.04"
-  location = "nbg1"
-  server_type = "cx22"
+  image = "ubuntu-24.04"
+  location = "hel1"
+  server_type = "cx23"
   ssh_username = "root"
 }
 

--- a/builder/hcloud/artifact_test.go
+++ b/builder/hcloud/artifact_test.go
@@ -70,7 +70,7 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 		StateData: map[string]interface{}{
 			"source_image":    "ubuntu-24.04",
 			"source_image_id": int64(161547269),
-			"server_type":     "cpx11",
+			"server_type":     "cpx22",
 		},
 	}
 
@@ -88,7 +88,7 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 		SourceImageID: "161547269",
 		Labels: map[string]string{
 			"source_image": "ubuntu-24.04",
-			"server_type":  "cpx11",
+			"server_type":  "cpx22",
 		},
 	}, image)
 }

--- a/builder/hcloud/step_create_server_test.go
+++ b/builder/hcloud/step_create_server_test.go
@@ -22,7 +22,7 @@ func TestStepCreateServer(t *testing.T) {
 			Step: &stepCreateServer{},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"})
 			},
 			WantRequests: []mockutil.Request{
 				{Method: "GET", Path: "/ssh_keys/1",
@@ -43,7 +43,7 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Equal(t, "dummy-server", payload.Name)
 						assert.Equal(t, int64(114690387), payload.Image.ID)
 						assert.Equal(t, "nbg1", payload.Location)
-						assert.Equal(t, "cpx11", payload.ServerType.Name)
+						assert.Equal(t, "cpx22", payload.ServerType.Name)
 						assert.True(t, payload.PublicNet.EnableIPv4)
 						assert.True(t, payload.PublicNet.EnableIPv6)
 						assert.Nil(t, payload.Networks)
@@ -94,7 +94,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"})
 			},
 			WantRequests: []mockutil.Request{
 				{Method: "GET", Path: "/ssh_keys/1",
@@ -121,7 +121,7 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Equal(t, "dummy-server", payload.Name)
 						assert.Equal(t, int64(114690387), payload.Image.ID)
 						assert.Equal(t, "nbg1", payload.Location)
-						assert.Equal(t, "cpx11", payload.ServerType.Name)
+						assert.Equal(t, "cpx22", payload.ServerType.Name)
 						assert.Equal(t, int64(986532), payload.Firewalls[0].Firewall)
 					},
 					Status: 201,
@@ -170,7 +170,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"})
 			},
 			WantRequests: []mockutil.Request{
 				{Method: "GET", Path: "/ssh_keys/1",
@@ -191,7 +191,7 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Equal(t, "dummy-server", payload.Name)
 						assert.Equal(t, int64(114690387), payload.Image.ID)
 						assert.Equal(t, "nbg1", payload.Location)
-						assert.Equal(t, "cpx11", payload.ServerType.Name)
+						assert.Equal(t, "cpx22", payload.ServerType.Name)
 						assert.Equal(t, []int64{12}, payload.Networks)
 					},
 					Status: 201,
@@ -242,7 +242,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"})
 			},
 			WantRequests: []mockutil.Request{
 				{Method: "GET", Path: "/ssh_keys/1",
@@ -289,7 +289,7 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Equal(t, "dummy-server", payload.Name)
 						assert.Equal(t, int64(114690387), payload.Image.ID)
 						assert.Equal(t, "nbg1", payload.Location)
-						assert.Equal(t, "cpx11", payload.ServerType.Name)
+						assert.Equal(t, "cpx22", payload.ServerType.Name)
 						assert.Nil(t, payload.Networks)
 						assert.NotNil(t, payload.PublicNet)
 						assert.Equal(t, int64(1), payload.PublicNet.IPv4ID)
@@ -342,7 +342,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"})
 			},
 			WantRequests: []mockutil.Request{
 				{Method: "GET", Path: "/ssh_keys/1",
@@ -395,7 +395,7 @@ func TestStepCreateServer(t *testing.T) {
 						assert.Equal(t, "dummy-server", payload.Name)
 						assert.Equal(t, int64(114690387), payload.Image.ID)
 						assert.Equal(t, "nbg1", payload.Location)
-						assert.Equal(t, "cpx11", payload.ServerType.Name)
+						assert.Equal(t, "cpx22", payload.ServerType.Name)
 						assert.Nil(t, payload.Networks)
 						assert.NotNil(t, payload.PublicNet)
 						assert.Equal(t, int64(1), payload.PublicNet.IPv4ID)
@@ -447,7 +447,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"})
 			},
 			WantRequests: []mockutil.Request{
 				{Method: "GET", Path: "/ssh_keys/1",
@@ -487,7 +487,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"})
 			},
 			WantRequests: []mockutil.Request{
 				{Method: "GET", Path: "/ssh_keys/1",
@@ -526,7 +526,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"})
 			},
 			WantRequests: []mockutil.Request{
 				{Method: "GET", Path: "/ssh_keys/1",
@@ -566,7 +566,7 @@ func TestStepCreateServer(t *testing.T) {
 			},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"})
 			},
 			WantRequests: []mockutil.Request{
 				{Method: "GET", Path: "/ssh_keys/1",
@@ -603,7 +603,7 @@ func TestStepCreateServer(t *testing.T) {
 			SetupConfigFunc: func(c *Config) {},
 			SetupStateFunc: func(state multistep.StateBag) {
 				state.Put(StateSSHKeyID, int64(1))
-				state.Put(StateServerType, &hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"})
+				state.Put(StateServerType, &hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"})
 			},
 			WantRequests: []mockutil.Request{
 				{Method: "GET", Path: "/ssh_keys/1",

--- a/builder/hcloud/step_pre_validate_test.go
+++ b/builder/hcloud/step_pre_validate_test.go
@@ -22,21 +22,21 @@ func TestStepPreValidate(t *testing.T) {
 				Force:        false,
 			},
 			SetupConfigFunc: func(c *Config) {
-				c.UpgradeServerType = "cpx21"
+				c.UpgradeServerType = "cpx32"
 			},
 			WantRequests: []mockutil.Request{
 				{
-					Method: "GET", Path: "/server_types?name=cpx11",
+					Method: "GET", Path: "/server_types?name=cpx22",
 					Status: 200,
 					JSONRaw: `{
-						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
+						"server_types": [{ "id": 109, "name": "cpx22", "architecture": "x86"}]
 					}`,
 				},
 				{
-					Method: "GET", Path: "/server_types?name=cpx21",
+					Method: "GET", Path: "/server_types?name=cpx32",
 					Status: 200,
 					JSONRaw: `{
-						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
+						"server_types": [{ "id": 110, "name": "cpx32", "architecture": "x86"}]
 					}`,
 				},
 				{
@@ -51,7 +51,7 @@ func TestStepPreValidate(t *testing.T) {
 			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
 				serverType, ok := state.Get(StateServerType).(*hcloud.ServerType)
 				assert.True(t, ok)
-				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"}, *serverType)
+				assert.Equal(t, hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"}, *serverType)
 
 				_, ok = state.Get(StateSnapshotIDOld).(int64)
 				assert.False(t, ok)
@@ -64,21 +64,21 @@ func TestStepPreValidate(t *testing.T) {
 				Force:        false,
 			},
 			SetupConfigFunc: func(c *Config) {
-				c.UpgradeServerType = "cpx21"
+				c.UpgradeServerType = "cpx32"
 			},
 			WantRequests: []mockutil.Request{
 				{
-					Method: "GET", Path: "/server_types?name=cpx11",
+					Method: "GET", Path: "/server_types?name=cpx22",
 					Status: 200,
 					JSONRaw: `{
-						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
+						"server_types": [{ "id": 109, "name": "cpx22", "architecture": "x86"}]
 					}`,
 				},
 				{
-					Method: "GET", Path: "/server_types?name=cpx21",
+					Method: "GET", Path: "/server_types?name=cpx32",
 					Status: 200,
 					JSONRaw: `{
-						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
+						"server_types": [{ "id": 110, "name": "cpx32", "architecture": "x86"}]
 					}`,
 				},
 				{
@@ -93,7 +93,7 @@ func TestStepPreValidate(t *testing.T) {
 			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
 				serverType, ok := state.Get(StateServerType).(*hcloud.ServerType)
 				assert.True(t, ok)
-				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"}, *serverType)
+				assert.Equal(t, hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"}, *serverType)
 
 				_, ok = state.Get(StateSnapshotIDOld).(int64)
 				assert.False(t, ok)
@@ -111,21 +111,21 @@ func TestStepPreValidate(t *testing.T) {
 				Force:        true,
 			},
 			SetupConfigFunc: func(c *Config) {
-				c.UpgradeServerType = "cpx21"
+				c.UpgradeServerType = "cpx32"
 			},
 			WantRequests: []mockutil.Request{
 				{
-					Method: "GET", Path: "/server_types?name=cpx11",
+					Method: "GET", Path: "/server_types?name=cpx22",
 					Status: 200,
 					JSONRaw: `{
-						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
+						"server_types": [{ "id": 109, "name": "cpx22", "architecture": "x86"}]
 					}`,
 				},
 				{
-					Method: "GET", Path: "/server_types?name=cpx21",
+					Method: "GET", Path: "/server_types?name=cpx32",
 					Status: 200,
 					JSONRaw: `{
-						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
+						"server_types": [{ "id": 110, "name": "cpx32", "architecture": "x86"}]
 					}`,
 				},
 				{
@@ -140,7 +140,7 @@ func TestStepPreValidate(t *testing.T) {
 			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
 				serverType, ok := state.Get(StateServerType).(*hcloud.ServerType)
 				assert.True(t, ok)
-				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"}, *serverType)
+				assert.Equal(t, hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"}, *serverType)
 
 				snapshotIDOld, ok := state.Get(StateSnapshotIDOld).(int64)
 				assert.True(t, ok)
@@ -153,22 +153,22 @@ func TestStepPreValidate(t *testing.T) {
 				SnapshotName: "dummy-snapshot",
 			},
 			SetupConfigFunc: func(c *Config) {
-				c.UpgradeServerType = "cpx21"
+				c.UpgradeServerType = "cpx32"
 				c.SkipCreateSnapshot = true
 			},
 			WantRequests: []mockutil.Request{
 				{
-					Method: "GET", Path: "/server_types?name=cpx11",
+					Method: "GET", Path: "/server_types?name=cpx22",
 					Status: 200,
 					JSONRaw: `{
-						"server_types": [{ "id": 9, "name": "cpx11", "architecture": "x86"}]
+						"server_types": [{ "id": 109, "name": "cpx22", "architecture": "x86"}]
 					}`,
 				},
 				{
-					Method: "GET", Path: "/server_types?name=cpx21",
+					Method: "GET", Path: "/server_types?name=cpx32",
 					Status: 200,
 					JSONRaw: `{
-						"server_types": [{ "id": 10, "name": "cpx21", "architecture": "x86"}]
+						"server_types": [{ "id": 110, "name": "cpx32", "architecture": "x86"}]
 					}`,
 				},
 			},
@@ -176,7 +176,7 @@ func TestStepPreValidate(t *testing.T) {
 			WantStateFunc: func(t *testing.T, state multistep.StateBag) {
 				serverType, ok := state.Get(StateServerType).(*hcloud.ServerType)
 				assert.True(t, ok)
-				assert.Equal(t, hcloud.ServerType{ID: 9, Name: "cpx11", Architecture: "x86"}, *serverType)
+				assert.Equal(t, hcloud.ServerType{ID: 109, Name: "cpx22", Architecture: "x86"}, *serverType)
 			},
 		},
 	})

--- a/builder/hcloud/step_test.go
+++ b/builder/hcloud/step_test.go
@@ -38,7 +38,7 @@ func RunStepTestCases(t *testing.T, testCases []StepTestCase) {
 				ServerName:   "dummy-server",
 				Image:        "debian-12",
 				SnapshotName: "dummy-snapshot",
-				ServerType:   "cpx11",
+				ServerType:   "cpx22",
 				Location:     "nbg1",
 				SSHKeys:      []string{"1"},
 			}

--- a/docs/builders/hcloud.mdx
+++ b/docs/builders/hcloud.mdx
@@ -153,9 +153,9 @@ access tokens:
 ```hcl
 source "hcloud" "basic_example" {
   token = "YOUR API TOKEN"
-  image = "ubuntu-22.04"
-  location = "nbg1"
-  server_type = "cx22"
+  image = "ubuntu-24.04"
+  location = "hel1"
+  server_type = "cx23"
   ssh_username = "root"
 }
 

--- a/example/basic/build.pkr.hcl
+++ b/example/basic/build.pkr.hcl
@@ -21,7 +21,7 @@ source "hcloud" "example" {
 
   location    = "hel1"
   image       = "ubuntu-24.04"
-  server_type = "cpx11"
+  server_type = "cpx22"
   server_name = "example-{{ timestamp }}"
 
   ssh_username = "root"

--- a/example/docker/build.pkr.hcl
+++ b/example/docker/build.pkr.hcl
@@ -21,7 +21,7 @@ source "hcloud" "docker" {
 
   location    = "hel1"
   image       = "ubuntu-24.04"
-  server_type = "cpx11"
+  server_type = "cpx22"
   server_name = "docker-{{ timestamp }}"
 
   user_data = <<-EOF

--- a/example/hcp/build.pkr.hcl
+++ b/example/hcp/build.pkr.hcl
@@ -21,7 +21,7 @@ source "hcloud" "example" {
 
   location    = "hel1"
   image       = "ubuntu-24.04"
-  server_type = "cpx11"
+  server_type = "cpx22"
   server_name = "example-{{ timestamp }}"
 
   ssh_username = "root"


### PR DESCRIPTION
The CX Gen 2 and CPX Gen 1 types are deprecated and will be removed from the API at the end of the year. This replaces all usages in our docs, so users do not have to figure it out themselves.
