### PR TITLE
test: use available server type for e2e tests

### DIFF
--- a/builder/hcloud/builder_acc_test.go
+++ b/builder/hcloud/builder_acc_test.go
@@ -49,8 +49,8 @@ const testBuilderAccBasic = `
 	"builders": [{
 		"type": "hcloud",
 		"location": "hel1",
-		"server_type": "cax11",
-		"image": "debian-12",
+		"server_type": "cpx22",
+		"image": "debian-13",
 		"user_data": "",
 		"user_data_file": "",
 		"ssh_username": "root"


### PR DESCRIPTION
Fix e2e tests by using an available server type in hel1.